### PR TITLE
Updated functions to use regex

### DIFF
--- a/kbupdate.psm1
+++ b/kbupdate.psm1
@@ -55,29 +55,23 @@ function Get-KbUpdate {
         # Also, I don't know regex, if anyone wants to PR with regex fixes, I'm down.
         function Get-Info ($Text, $Pattern) {
             # sorry, don't know regex. this is ugly af.
-            $info = $Text -Split $Pattern
             if ($Pattern -match "labelTitle") {
-                $part = ($info[1] -Split '</span>')[1]
-                $part = $part.Replace("<div>", "")
-                ($part -Split '</div>')[0].Trim()
+                # this should work... not accounting for multiple divs however?
+                [regex]::Match($detaildialog, $Pattern + '[\s\S]*<div>\s*(.*?)\s*<\/div>').Groups[1].Value
             } elseif ($Pattern -match "span ") {
                 [regex]::Match($detaildialog, $Pattern + '(.*?)<\/span>').Groups[1].Value
-            } else {
-                ($info[1] -Split ';')[0].Replace("'", "").Trim()
             }
         }
 
         function Get-SuperInfo ($Text, $Pattern) {
             $info = $Text -Split $Pattern
             if ($Pattern -match "supersededbyInfo") {
-                $part = ($info[1] -Split '<span id="ScopedViewHandler_labelSupersededUpdates_Separator" class="labelTitle">')[0]
+                $span = [regex]::match($Text, '<div id="supersededbyInfo" TABINDEX="1" >[\s\S]*?<span')
+                [regex]::Matches($span, "<div[\s\S]*?'>(.*?)<\/a>").ForEach({ $_.Groups[1].Value })
             } else {
-                $part = ($info[1] -Split '<div id="languageBox" style="display: none">')[0]
-            }
-            $nomarkup = ($part -replace '<[^>]+>', '').Trim() -split [Environment]::NewLine
-            foreach ($line in $nomarkup) {
-                $clean = $line.Trim()
-                if ($clean) { $clean }
+                $span = [regex]::match($Text, $Pattern + '[\s\S]*?<span')
+                [regex]::Matches($span, "<div style.*>\s*(.*)\s*<\/div>").ForEach({ $_.Groups[1].Value })
+
             }
         }
 

--- a/kbupdate.psm1
+++ b/kbupdate.psm1
@@ -52,9 +52,7 @@ function Get-KbUpdate {
     )
     begin {
         # Wishing Microsoft offered an RSS feed. Since they don't, we are forced to parse webpages.
-        # Also, I don't know regex, if anyone wants to PR with regex fixes, I'm down.
         function Get-Info ($Text, $Pattern) {
-            # sorry, don't know regex. this is ugly af.
             if ($Pattern -match "labelTitle") {
                 # this should work... not accounting for multiple divs however?
                 [regex]::Match($detaildialog, $Pattern + '[\s\S]*<div>\s*(.*?)\s*<\/div>').Groups[1].Value
@@ -64,7 +62,6 @@ function Get-KbUpdate {
         }
 
         function Get-SuperInfo ($Text, $Pattern) {
-            $info = $Text -Split $Pattern
             if ($Pattern -match "supersededbyInfo") {
                 $span = [regex]::match($Text, '<div id="supersededbyInfo" TABINDEX="1" >[\s\S]*?<span')
                 [regex]::Matches($span, "<div[\s\S]*?'>(.*?)<\/a>").ForEach({ $_.Groups[1].Value })


### PR DESCRIPTION
Both get-info and get-superinfo now use regex instead of splitting/parsing lines.
The get-superinfo function utilises a foreach due to multiple divs but shouldn't have any impact.

Fingers crossed!