### PR TITLE
Format SuperseededBy and Supersedes into custom objects

### DIFF
--- a/public/Get-KbUpdate.ps1
+++ b/public/Get-KbUpdate.ps1
@@ -80,10 +80,25 @@ function Get-KbUpdate {
             switch -Wildcard ($span.Value) {
                 "*div style*" { $regex = '">\s*(.*?)\s*<\/div>' }
                 "*a href*" { $regex = "<div[\s\S]*?'>(.*?)<\/a" }
-                default { $regex = '"\s?>\s*(\S+?)\s*<\/div>'}
+                default { $regex = '"\s?>\s*(\S+?)\s*<\/div>' }
             }
 
-            [regex]::Matches($span, $regex).ForEach( { $_.Groups[1].Value })
+            $spanMatches = [regex]::Matches($span, $regex).ForEach( { $_.Groups[1].Value })
+            if ($spanMatches) {
+                if ($spanMatches -ne 'n/a') {
+                    foreach ($superMatch in $spanMatches) {
+                        $detailedMatches = [regex]::Matches($superMatch, '\b[kK][bB]([0-9]{6,})\b')
+                        if ($null -ne $detailedMatches) {
+                            [PSCustomObject] @{
+                                'KB'          = $detailedMatches.Groups[1].Value
+                                'Description' = $superMatch
+                            }
+                        }
+                    }
+                } else {
+                    $spanMatches
+                }
+            }
         }
 
         # put everything in this function so that it can be easily cached
@@ -94,8 +109,8 @@ function Get-KbUpdate {
                 Write-Progress -Activity "Searching catalog for $kb" -Id 1 -Completed
 
                 $kbids = $results.InputFields |
-                    Where-Object { $_.type -eq 'Button' -and $_.Value -eq 'Download' } |
-                    Select-Object -ExpandProperty  ID
+                Where-Object { $_.type -eq 'Button' -and $_.Value -eq 'Download' } |
+                Select-Object -ExpandProperty  ID
 
                 if (-not $kbids) {
                     try {

--- a/tests/Integration.Tests.ps1
+++ b/tests/Integration.Tests.ps1
@@ -19,21 +19,21 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
             $results.Language          | Should -Be "All"
             $results.Classification    | Should -Be "Security Updates"
             $results.SupportedProducts | Should -Be "ASP.NET Web Frameworks"
-            $results.MSRCNumber        | Should -Be "MS14-059"
-            $results.MSRCSeverity      | Should -Be "Important"
-            $results.Hotfix            | Should -Be "True"
-            $results.Size              | Should -Be "462 KB"
-            $results.UpdateId          | Should -Be "0c84df7a-e685-466c-a545-a24de5ad2601"
-            $results.RebootBehavior    | Should -Be "Can request restart"
+            $results.MSRCNumber | Should -Be "MS14-059"
+            $results.MSRCSeverity | Should -Be "Important"
+            $results.Hotfix | Should -Be "True"
+            $results.Size | Should -Be "462 KB"
+            $results.UpdateId | Should -Be "0c84df7a-e685-466c-a545-a24de5ad2601"
+            $results.RebootBehavior | Should -Be "Can request restart"
             $results.RequestsUserInput | Should -Be "No"
-            $results.ExclusiveInstall  | Should -Be "No"
-            $results.NetworkRequired   | Should -Be "No"
-            $results.UninstallNotes    | Should -Be "This software update can be removed via Add or Remove Programs in Control Panel."
-            $results.UninstallSteps    | Should -Be "n/a"
-            $results.SupersededBy      | Should -Be "n/a"
-            $results.Supersedes        | Should -Be "n/a"
-            $results.LastModified      | Should -Be "10/14/2014"
-            $results.Link              | Should -Be "http://download.windowsupdate.com/c/msdownload/update/software/secu/2014/10/aspnetwebfxupdate_kb2992080_55c239c6b443cb122b04667a9be948b03046bf88.exe"
+            $results.ExclusiveInstall | Should -Be "No"
+            $results.NetworkRequired | Should -Be "No"
+            $results.UninstallNotes | Should -Be "This software update can be removed via Add or Remove Programs in Control Panel."
+            $results.UninstallSteps | Should -Be "n/a"
+            $results.SupersededBy | Should -Be "n/a"
+            $results.Supersedes | Should -Be "n/a"
+            $results.LastModified | Should -Be "10/14/2014"
+            $results.Link | Should -Be "http://download.windowsupdate.com/c/msdownload/update/software/secu/2014/10/aspnetwebfxupdate_kb2992080_55c239c6b443cb122b04667a9be948b03046bf88.exe"
         }
         It "returns correct 404 when found in the catalog" {
             $foundit = Get-KbUpdate -Name 4482972 3>&1 | Out-String
@@ -42,6 +42,31 @@ Describe "Integration Tests" -Tag "IntegrationTests" {
         It "returns correct 404 when not found in the catalog" {
             $notfound = Get-KbUpdate -Name 4482972abc123 3>&1 | Out-String
             $notfound | Should -Match "No results found"
+        }
+        It "returns objects for Supersedes and SupersededBy" {
+            $results = Get-KbUpdate -Name KB4505225
+            $results.Title | Should -Be 'Security Update for SQL Server 2017 RTM CU (KB4505225)'
+            $results.Supersedes.KB | Should -Be @(
+                '4293805',
+                '4058562',
+                '4494352',
+                '4038634',
+                '4342123',
+                '4462262',
+                '4464082',
+                '4466404',
+                '4484710',
+                '4498951',
+                '4052574',
+                '4052987',
+                '4056498',
+                '4092643',
+                '4101464',
+                '4229789',
+                '4338363',
+                '4341265'
+            )
+
         }
     }
     Context "Save works" {

--- a/tests/general/Help.Tests.ps1
+++ b/tests/general/Help.Tests.ps1
@@ -10,7 +10,7 @@
 
 	.PARAMETER SkipTest
 		Disables this test.
-	
+
 	.PARAMETER CommandPath
 		List of paths under which the script files are stored.
 		This test assumes that all functions have their own file that is named after themselves.
@@ -32,17 +32,17 @@
 #>
 [CmdletBinding()]
 Param (
-	[switch]
-	$SkipTest,
-	
-	[string[]]
-	$CommandPath = @("$PSScriptRoot\..\..\functions", "$PSScriptRoot\..\..\internal\functions"),
-	
-	[string]
-	$ModuleName = "SPReplicator",
-	
-	[string]
-	$ExceptionsFile = "$PSScriptRoot\Help.Exceptions.ps1"
+    [switch]
+    $SkipTest,
+
+    [string[]]
+    $CommandPath = @("$PSScriptRoot\..\..\public", "$PSScriptRoot\..\..\private"),
+
+    [string]
+    $ModuleName = "kbupdate",
+
+    [string]
+    $ExceptionsFile = "$PSScriptRoot\Help.Exceptions.ps1"
 )
 if ($SkipTest) { return }
 . $ExceptionsFile
@@ -56,16 +56,16 @@ $commands = Get-Command -Module (Get-Module $ModuleName) -CommandType Cmdlet, Fu
 
 foreach ($command in $commands) {
     $commandName = $command.Name
-    
+
     # Skip all functions that are on the exclusions list
     if ($global:FunctionHelpTestExceptions -contains $commandName) { continue }
-    
+
     # The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
     $Help = Get-Help $commandName -ErrorAction SilentlyContinue
     $testhelperrors = 0
     $testhelpall = 0
     Describe "Test help for $commandName" {
-        
+
         $testhelpall += 1
         if ($Help.Synopsis -like '*`[`<CommonParameters`>`]*') {
             # If help is not found, synopsis in auto-generated help is the syntax diagram
@@ -74,7 +74,7 @@ foreach ($command in $commands) {
             }
             $testhelperrors += 1
         }
-        
+
         $testhelpall += 1
         if ([String]::IsNullOrEmpty($Help.Description.Text)) {
             # Should be a description for every function
@@ -83,7 +83,7 @@ foreach ($command in $commands) {
             }
             $testhelperrors += 1
         }
-        
+
         $testhelpall += 1
         if ([String]::IsNullOrEmpty(($Help.Examples.Example | Select-Object -First 1).Code)) {
             # Should be at least one example
@@ -92,7 +92,7 @@ foreach ($command in $commands) {
             }
             $testhelperrors += 1
         }
-        
+
         $testhelpall += 1
         if ([String]::IsNullOrEmpty(($Help.Examples.Example.Remarks | Select-Object -First 1).Text)) {
             # Should be at least one example description
@@ -101,27 +101,27 @@ foreach ($command in $commands) {
             }
             $testhelperrors += 1
         }
-        
+
         if ($testhelperrors -eq 0) {
             It "Ran silently $testhelpall tests" {
                 $testhelperrors | Should be 0
             }
         }
-        
+
         $testparamsall = 0
         $testparamserrors = 0
         Context "Test parameter help for $commandName" {
-            
+
             $Common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable',
             'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable'
-            
+
             $parameters = $command.ParameterSets.Parameters | Sort-Object -Property Name -Unique | Where-Object Name -notin $common
             $parameterNames = $parameters.Name
             $HelpParameterNames = $Help.Parameters.Parameter.Name | Sort-Object -Unique
             foreach ($parameter in $parameters) {
                 $parameterName = $parameter.Name
                 $parameterHelp = $Help.parameters.parameter | Where-Object Name -EQ $parameterName
-                
+
                 $testparamsall += 1
                 if ([String]::IsNullOrEmpty($parameterHelp.Description.Text)) {
                     # Should be a description for every parameter
@@ -130,7 +130,7 @@ foreach ($command in $commands) {
                     }
                     $testparamserrors += 1
                 }
-                
+
                 $testparamsall += 1
                 $codeMandatory = $parameter.IsMandatory.toString()
                 if ($parameterHelp.Required -ne $codeMandatory) {
@@ -140,11 +140,11 @@ foreach ($command in $commands) {
                     }
                     $testparamserrors += 1
                 }
-                
+
                 if ($HelpTestSkipParameterType[$commandName] -contains $parameterName) { continue }
-                
+
                 $codeType = $parameter.ParameterType.Name
-                
+
                 $testparamsall += 1
                 if ($parameter.ParameterType.IsEnum) {
                     # Enumerations often have issues with the typename not being reliably available
@@ -156,8 +156,7 @@ foreach ($command in $commands) {
                         }
                         $testparamserrors += 1
                     }
-                }
-                elseif ($parameter.ParameterType.FullName -in $HelpTestEnumeratedArrays) {
+                } elseif ($parameter.ParameterType.FullName -in $HelpTestEnumeratedArrays) {
                     # Enumerations often have issues with the typename not being reliably available
                     $names = [Enum]::GetNames($parameter.ParameterType.DeclaredMembers[0].ReturnType)
                     if ($parameterHelp.parameterValueGroup.parameterValue -ne $names) {
@@ -167,8 +166,7 @@ foreach ($command in $commands) {
                         }
                         $testparamserrors += 1
                     }
-                }
-                else {
+                } else {
                     # To avoid calling Trim method on a null object.
                     $helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
                     if ($helpType -ne $codeType) {

--- a/tests/general/Manifest.Tests.ps1
+++ b/tests/general/Manifest.Tests.ps1
@@ -1,44 +1,41 @@
 Describe "Validating the module manifest" {
-	$moduleRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
-	$manifest = ((Get-Content "$moduleRoot\SPReplicator.psd1") -join "`n") | Invoke-Expression
-	
-	Context "Basic resources validation" {
-		It "Exports all functions in the public folder" {
-			$files = Get-ChildItem "$moduleRoot\functions" -Recurse -File -Filter "*.ps1"
-			$count = (Compare-Object -ReferenceObject $files.BaseName -DifferenceObject $manifest.FunctionsToExport).Count
-			$count | Should be 0
-		}
-		
-		It "Exports none of its internal functions" {
-			$files = Get-ChildItem "$moduleRoot\internal\functions" -Recurse -File -Filter "*.ps1"
-			$files | Where-Object BaseName -In $manifest.FunctionsToExport | Should Be $null
-		}
-	}
-	
-	Context "Individual file validation" {
-		It "The root module file exists" {
-			Test-Path "$moduleRoot\$($manifest.RootModule)" | Should Be $true
-		}
-		
-		foreach ($format in $manifest.FormatsToProcess)
-		{
-			It "The file $format should exist" {
-				Test-Path "$moduleRoot\$format" | Should Be $true
-			}
-		}
-		
-		foreach ($type in $manifest.TypesToProcess)
-		{
-			It "The file $type should exist" {
-				Test-Path "$moduleRoot\$type" | Should Be $true
-			}
-		}
-		
-		foreach ($assembly in $manifest.RequiredAssemblies)
-		{
-			It "The file $assembly should exist" {
-				Test-Path "$moduleRoot\$assembly" | Should Be $true
-			}
-		}
-	}
+    $moduleRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
+    $manifest = ((Get-Content "$moduleRoot\kbupdate.psd1") -join "`n") | Invoke-Expression
+
+    Context "Basic resources validation" {
+        It "Exports all functions in the public folder" {
+            $files = Get-ChildItem "$moduleRoot\public" -Recurse -File -Filter "*.ps1"
+            $count = (Compare-Object -ReferenceObject $files.BaseName -DifferenceObject $manifest.FunctionsToExport).Count
+            $count | Should be 0
+        }
+
+        It "Exports none of its private functions" {
+            $files = Get-ChildItem "$moduleRoot\private" -Recurse -File -Filter "*.ps1"
+            $files | Where-Object BaseName -In $manifest.FunctionsToExport | Should Be $null
+        }
+    }
+
+    Context "Individual file validation" {
+        It "The root module file exists" {
+            Test-Path "$moduleRoot\$($manifest.RootModule)" | Should Be $true
+        }
+
+        foreach ($format in $manifest.FormatsToProcess) {
+            It "The file $format should exist" {
+                Test-Path "$moduleRoot\$format" | Should Be $true
+            }
+        }
+
+        foreach ($type in $manifest.TypesToProcess) {
+            It "The file $type should exist" {
+                Test-Path "$moduleRoot\$type" | Should Be $true
+            }
+        }
+
+        foreach ($assembly in $manifest.RequiredAssemblies) {
+            It "The file $assembly should exist" {
+                Test-Path "$moduleRoot\$assembly" | Should Be $true
+            }
+        }
+    }
 }

--- a/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -1,10 +1,10 @@
 [CmdletBinding()]
 Param (
-	[switch]
-	$SkipTest,
-	
-	[string[]]
-	$CommandPath = @("$PSScriptRoot\..\..\functions", "$PSScriptRoot\..\..\internal\functions")
+    [switch]
+    $SkipTest,
+
+    [string[]]
+    $CommandPath = @("$PSScriptRoot\..\..\public", "$PSScriptRoot\..\..\private")
 )
 
 if ($SkipTest) { return }
@@ -14,31 +14,26 @@ if ($env:BUILD_BUILDURI -like "vstfs*") { Install-Module PSScriptAnalyzer -Force
 $list = New-Object System.Collections.ArrayList
 
 Describe 'Invoking PSScriptAnalyzer against commandbase' {
-	$commandFiles = Get-ChildItem -Path $CommandPath -Recurse -Filter "*.ps1"
-	$scriptAnalyzerRules = Get-ScriptAnalyzerRule
-	
-	foreach ($file in $commandFiles)
-	{
-		Context "Analyzing $($file.BaseName)" {
-			$analysis = Invoke-ScriptAnalyzer -Path $file.FullName -ExcludeRule PSAvoidTrailingWhitespace, PSAvoidGlobalVars, PSShouldProcess
-			
-			forEach ($rule in $scriptAnalyzerRules)
-			{
-				It "Should pass $rule" {
-					If ($analysis.RuleName -contains $rule)
-					{
-						$analysis | Where-Object RuleName -EQ $rule -outvariable failures | ForEach-Object { $list.Add($_) }
-						
-						1 | Should Be 0
-					}
-					else
-					{
-						0 | Should Be 0
-					}
-				}
-			}
-		}
-	}
+    $commandFiles = Get-ChildItem -Path $CommandPath -Recurse -Filter "*.ps1"
+    $scriptAnalyzerRules = Get-ScriptAnalyzerRule
+
+    foreach ($file in $commandFiles) {
+        Context "Analyzing $($file.BaseName)" {
+            $analysis = Invoke-ScriptAnalyzer -Path $file.FullName -ExcludeRule PSAvoidTrailingWhitespace, PSAvoidGlobalVars, PSShouldProcess
+
+            forEach ($rule in $scriptAnalyzerRules) {
+                It "Should pass $rule" {
+                    If ($analysis.RuleName -contains $rule) {
+                        $analysis | Where-Object RuleName -EQ $rule -outvariable failures | ForEach-Object { $list.Add($_) }
+
+                        1 | Should Be 0
+                    } else {
+                        0 | Should Be 0
+                    }
+                }
+            }
+        }
+    }
 }
 
 $list | Out-Default


### PR DESCRIPTION
Format SuperseededBy and Supersedes properties from Get-KbUpdate into custom objects. This parses out the KB number into its own property so it can be easily compared to Get-DbaBuildReference.

My IDE changed a bunch of formatting on files... I'm not sure how to fix it 😥