### PR TITLE
Replaced multiple if statements with regex switch statements

### DIFF
--- a/public/Get-KbUpdate.ps1
+++ b/public/Get-KbUpdate.ps1
@@ -332,42 +332,14 @@ function Get-KbUpdate {
                 if ($link -eq "") {
                     $link = $null
                 }
-
-                if ($title -match "ia32") {
-                    $arch = "IA32"
-                }
-                if ($title -match "ia64") {
-                    $arch = "IA64"
-                }
-                if ($title -match "64-Bit" -and $title -notmatch "32-Bit" -and -not $arch) {
-                    $arch = "x64"
-                }
-                if ($title -notmatch "64-Bit" -and $title -match "32-Bit" -and -not $arch) {
-                    $arch = "x86"
-                }
-                if ($title -match "x64" -or $title -match "AMD64") {
-                    $arch = "x64"
-                }
-                if ($title -match "x86") {
-                    $arch = "x86"
-                }
-                if ($title -match "ARM64") {
-                    $arch = "ARM64"
-                }
-                if ($title -match "ARM-based") {
-                    $arch = "ARM32"
-                }
-                if ($link -match "x64" -or $link -match "AMD64" -and -not $arch) {
-                    $arch = "x64"
-                }
-                if ($link -match "x86" -and -not $arch) {
-                    $arch = "x86"
-                }
-                if ($link -match "ARM64" -and -not $arch) {
-                    $arch = "ARM64"
-                }
-                if ($link -match "ARM-based" -and -not $arch) {
-                    $arch = "ARM32"
+                $arch = switch -regex ($title) {
+                    ".*ia32.*" { "IA32" }
+                    ".*ia64.*" { "IA64" }
+                    ".*(32-Bit|x86).*" { "x86" }
+                    ".*(x64|AMD64|64-Bit).*" { "x64" }
+                    ".*ARM64.*" { "ARM64" }
+                    ".*ARM-based.*" { "ARM32" }
+                    default { $null } # Handle the case if no matching architecture is found
                 }
 
                 if ($wsuskb.ArrivalDate) {
@@ -615,29 +587,14 @@ function Get-KbUpdate {
                     if ($longlang -eq "all") {
                         $longlang = "All"
                     }
-                    if ($title -match "ia32") {
-                        $arch = "IA32"
-                    }
-                    if ($title -match "ia64") {
-                        $arch = "IA64"
-                    }
-                    if ($title -match "64-Bit" -and $title -notmatch "32-Bit" -and -not $arch) {
-                        $arch = "x64"
-                    }
-                    if ($title -notmatch "64-Bit" -and $title -match "32-Bit" -and -not $arch) {
-                        $arch = "x86"
-                    }
-                    if ($title -match "x64" -or $title -match "AMD64") {
-                        $arch = "x64"
-                    }
-                    if ($title -match "x86") {
-                        $arch = "x86"
-                    }
-                    if ($title -match "ARM64") {
-                        $arch = "ARM64"
-                    }
-                    if ($title -match "ARM-based") {
-                        $arch = "ARM32"
+                    $arch = switch -regex ($title) {
+                        ".*ia32.*" { "IA32" }
+                        ".*ia64.*" { "IA64" }
+                        ".*(32-Bit|x86).*" { "x86" }
+                        ".*(x64|AMD64|64-Bit).*" { "x64" }
+                        ".*ARM64.*" { "ARM64" }
+                        ".*ARM-based.*" { "ARM32" }
+                        default { $null } # Handle the case if no matching architecture is found
                     }
 
                     if (-not $Simple) {
@@ -680,17 +637,14 @@ function Get-KbUpdate {
                         if ($arch -eq "n/a") {
                             $arch = $null
                         }
-                        if ($link -match "x64" -or $link -match "AMD64") {
-                            $arch = "x64"
-                        }
-                        if ($link -match "x86") {
-                            $arch = "x86"
-                        }
-                        if ($link -match "ARM64") {
-                            $arch = "ARM64"
-                        }
-                        if ($link -match "ARM-based") {
-                            $arch = "ARM32"
+                        $arch = switch -regex ($link) {
+                            ".*ia32.*" { "IA32" }
+                            ".*ia64.*" { "IA64" }
+                            ".*(32-Bit|x86).*" { "x86" }
+                            ".*(x64|AMD64|64-Bit).*" { "x64" }
+                            ".*ARM64.*" { "ARM64" }
+                            ".*ARM-based.*" { "ARM32" }
+                            default { $null } # Handle the case if no matching architecture is found
                         }
 
                         if ($kbnumbers -eq "n/a") {

--- a/public/Get-KbUpdate.ps1
+++ b/public/Get-KbUpdate.ps1
@@ -261,41 +261,25 @@ function Get-KbUpdate {
                     if ($item.Architecture -eq "n/a") {
                         $item.Architecture = $null
                     }
-                    if ($item.title -match "ia32") {
-                        $item.Architecture = "IA32"
+                    $item.Architecture = switch -regex ($item.title) {
+                        ".*ia32.*" { "IA32" }
+                        ".*ia64.*" { "IA64" }
+                        ".*(32-Bit|x86).*" { "x86" }
+                        ".*(x64|AMD64|64-Bit).*" { "x64" }
+                        ".*ARM64.*" { "ARM64" }
+                        ".*ARM-based.*" { "ARM32" }
+                        default { $null } # Handle the case if no matching architecture is found
                     }
-                    if ($item.title -match "ia64") {
-                        $item.Architecture = "IA64"
-                    }
-                    if ($item.title -match "64-Bit" -and $item.title -notmatch "32-Bit" -and -not $item.Architecture) {
-                        $item.Architecture = "x64"
-                    }
-                    if ($item.title -notmatch "64-Bit" -and $item.title -match "32-Bit" -and -not $item.Architecture) {
-                        $item.Architecture = "x86"
-                    }
-                    if ($item.title -match "x64" -or $item.title -match "AMD64") {
-                        $item.Architecture = "x64"
-                    }
-                    if ($item.title -match "x86") {
-                        $item.Architecture = "x86"
-                    }
-                    if ($item.title -match "ARM64") {
-                        $item.Architecture = "ARM64"
-                    }
-                    if ($item.title -match "ARM-based") {
-                        $item.Architecture = "ARM32"
-                    }
-                    if ($item.link -match "x64" -or $item.link -match "AMD64" -and -not $item.Architecture) {
-                        $item.Architecture = "x64"
-                    }
-                    if ($item.link -match "x86" -and -not $item.Architecture) {
-                        $item.Architecture = "x86"
-                    }
-                    if ($item.link -match "ARM64" -and -not $item.Architecture) {
-                        $item.Architecture = "ARM64"
-                    }
-                    if ($item.link -match "ARM-based" -and -not $item.Architecture) {
-                        $item.Architecture = "ARM32"
+                    if(-not $item.Architecture){
+                        $item.Architecture = switch -regex ($item.link) {
+                            ".*ia32.*" { "IA32" }
+                            ".*ia64.*" { "IA64" }
+                            ".*(32-Bit|x86).*" { "x86" }
+                            ".*(x64|AMD64|64-Bit).*" { "x64" }
+                            ".*ARM64.*" { "ARM64" }
+                            ".*ARM-based.*" { "ARM32" }
+                            default { $null } # Handle the case if no matching architecture is found
+                        }
                     }
                     if ($item.LastModified) {
                         $item.LastModified = Repair-Date $item.LastModified


### PR DESCRIPTION
Refactored code to improve architecture determination:
- Replaced multiple if statements with regex switch statements for better readability and maintainability.
- Initially, the architecture is determined based on the hints in the 'title' property. If any hints match, the architecture is assigned accordingly. Otherwise, it is set to $null.
- If the architecture is still null, a fallback mechanism has been implemented. The 'link' property is then used to further determine the architecture.
- These changes simplify the code and enhance its flexibility in identifying the architecture.

Hey Chrissy, I hope you are fine with my improvements.
To test them you can check this code:
```PowerShell


$titles = @(
    "Intel IA32 Processor",
    "Intel IA64 Processor",
    "Intel 64-Bit Processor",
    "Intel 32-Bit Processor",
    "AMD64 Processor",
    "Intel x64 Processor",
    "Intel x86 Processor",
    "ARM64 Processor",
    "ARM-based Processor"
)

foreach ($title in $titles) {
    $item = [PSCustomObject]@{
        title = $title
        Architecture = $null
    }

    $item.Architecture = switch -regex ($item.title) {
        ".*ia32.*" { "IA32" }
        ".*ia64.*" { "IA64" }
        ".*(32-Bit|x86).*" { "x86" }
        ".*(x64|AMD64|64-Bit).*" { "x64" }
        ".*ARM64.*" { "ARM64" }
        ".*ARM-based.*" { "ARM32" }
        default { $null } # Handle the case if no matching architecture is found
    }
    

    Write-Host "Title: $($item.title) | Architecture: $($item.Architecture)"
}
```

If you like I could check for other improvements as well :)