### PR TITLE
Update Save-KbUpdate.ps1

### DIFF
--- a/public/Save-KbUpdate.ps1
+++ b/public/Save-KbUpdate.ps1
@@ -231,7 +231,7 @@ function Save-KbUpdate {
                     $inputobjects += Get-KbUpdate @params
                 }
 
-                $inputobjects = $inputobjects | Sort-Object -Unique
+                $inputobjects = $inputobjects | Sort-Object -Property UpdateId -Unique
 
                 foreach ($object in $inputobjects) {
                     if ($Architecture) {


### PR DESCRIPTION
On line 234, the "Sort-Object -Unique" would often return only one result from a multiple object result from Get-KBUpdate. For example, testing KB5035285, which returns 7 files, would only actually download one of the files. Most of the properties were the same across the board, so only one was selected as "unique".

Set the unique sort to the UpdateID, which should actually be unique across each file, and we'll download them all.