### PR TITLE
Fix overwriting issue when downloading multiple updates for the same …

### DIFF
--- a/public/Save-KbUpdate.ps1
+++ b/public/Save-KbUpdate.ps1
@@ -255,9 +255,9 @@ function Save-KbUpdate {
                         }
                     }
 
-                    foreach ($dl in $object) {
+                    foreach ($dl in $object.Link) {
                         $title = $dl.Title
-                        $hyperlinklol = $object.Link
+                        $hyperlinklol = $dl
                         if (-not $PSBoundParameters.FilePath) {
                             $FilePath = Split-Path -Path $hyperlinklol -Leaf
                         } else {


### PR DESCRIPTION
Fix for https://github.com/potatoqualitee/kbupdate/issues/224

When a given -Name parameter corresponds to multiple updates (download links), all files are downloaded to the same filename, causing each subsequent file to overwrite the previous one. Additionally, the resulting filename includes all update names concatenated together.