### PR TITLE
Support BITS jobs in PowerShell 7

### DIFF
--- a/private/Start-BitsJobProcess.ps1
+++ b/private/Start-BitsJobProcess.ps1
@@ -2,7 +2,7 @@ function Start-BitsJobProcess {
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline)]
-        [Microsoft.BackgroundIntelligentTransfer.Management.BitsJob[]]$InputObject,
+        [object[]]$InputObject,
         [switch]$EnableException
     )
     begin {

--- a/tests/unit/Start-BitsJobProcess.Tests.ps1
+++ b/tests/unit/Start-BitsJobProcess.Tests.ps1
@@ -1,4 +1,5 @@
 BeforeAll {
+    function Get-BitsTransfer { }
     . (Join-Path $PSScriptRoot '../../private/Start-BitsJobProcess.ps1')
 }
 

--- a/tests/unit/Start-BitsJobProcess.Tests.ps1
+++ b/tests/unit/Start-BitsJobProcess.Tests.ps1
@@ -1,0 +1,28 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../private/Start-BitsJobProcess.ps1')
+}
+
+Describe 'Start-BitsJobProcess PowerShell compatibility' {
+    It 'accepts a BITS-shaped object without requiring the Windows-only BitsJob type' {
+        $file = [pscustomobject]@{
+            Count     = 1
+            LocalName = 'C:\temp\update.msu'
+        }
+        $job = [pscustomobject]@{
+            BytesTotal       = 1024
+            BytesTransferred = 0
+            FileList         = $file
+        }
+
+        Mock Get-BitsTransfer { @() }
+        Mock Get-ChildItem { @() }
+        Mock Write-Progress
+
+        { $job | Start-BitsJobProcess } | Should -Not -Throw
+        Should -Invoke Get-BitsTransfer -Times 1
+    }
+
+    It 'declares InputObject using a runtime-neutral object array' {
+        (Get-Command Start-BitsJobProcess).Parameters.InputObject.ParameterType | Should -Be ([object[]])
+    }
+}


### PR DESCRIPTION
## What changed

- replaces the compile-time `Microsoft.BackgroundIntelligentTransfer.Management.BitsJob[]` parameter with a runtime-neutral object array
- adds regression coverage using a BITS-shaped object under PowerShell 7
- verifies the public helper metadata no longer references the unavailable Windows PowerShell type

## Root cause

PowerShell resolves a declared parameter type before parameter binding. PowerShell 7 can expose the BITS commands without exposing the Windows PowerShell `BitsJob` CLR type, so `$PSDefaultParameterValues` cannot help: invocation fails before defaults are considered.

## Validation

- targeted Pester tests: 2 passed
- `./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap`: 21 passed

Closes #206