### PR TITLE
Bound and clean up BITS job failures

### DIFF
--- a/private/Start-BitsJobProcess.ps1
+++ b/private/Start-BitsJobProcess.ps1
@@ -22,8 +22,11 @@ function Start-BitsJobProcess {
         $bs = $jobs | Where-Object BytesTotal -ne 18446744073709551615
         $bytestotal = ($bs.BytesTotal | Measure-Object -Sum).Sum
         $bstotal = [math]::Round(($bytestotal / 1MB),2)
+        $jobIds = @($jobs | Select-Object -ExpandProperty JobId)
+        $retryCounts = @{}
+        $maximumRetries = 3
 
-        while ($bitsjobs = (Get-BitsTransfer | Where-Object Description -match kbupdate)) {
+        while ($bitsjobs = @(Get-BitsTransfer | Where-Object { $PSItem.JobId -in $jobIds })) {
             $bytesjob = $bitsjobs | Where-Object BytesTotal -ne 18446744073709551615
             $bjbytestotal = ($bytesjob.BytesTransferred | Measure-Object -Sum).Sum
             $mbjtotal = [math]::Round(($bjbytestotal / 1MB),2)
@@ -68,21 +71,32 @@ function Start-BitsJobProcess {
                                 Get-ChildItem $filename
                             }
                         }
-                        "Suspended" {
-                            foreach ($filename in $bitsjob.FileList.LocalName) {
-                                Write-PSFMessage -Level Verbose -Message "Oof, $filename is suspended. Retrying."
+                        { $PSItem -in "Suspended", "TransientError" } {
+                            $retryKey = "$($bitsjob.JobId)"
+                            if (-not $retryCounts.ContainsKey($retryKey)) {
+                                $retryCounts[$retryKey] = 0
                             }
-                            $null = $bitsjob | Resume-BitsTransfer
+                            $retryCounts[$retryKey]++
+                            foreach ($filename in $bitsjob.FileList.LocalName) {
+                                Write-PSFMessage -Level Verbose -Message "Oof, $filename is $($bitsjob.JobState). Retry $($retryCounts[$retryKey]) of $maximumRetries."
+                            }
+                            if ($retryCounts[$retryKey] -ge $maximumRetries) {
+                                $null = Remove-BitsTransfer -BitsJob $bitsjob -Confirm:$false -ErrorAction Ignore
+                                Stop-PSFFunction -Message "Failure downloading $title after $maximumRetries retries | $($bitsjob.ErrorDescription)" -Continue
+                            } else {
+                                $null = Resume-BitsTransfer -BitsJob $bitsjob -Asynchronous -ErrorAction Ignore
+                            }
                         }
-                        "Error" {
+                        { $PSItem -in "Error", "Cancelled" } {
+                            $null = Remove-BitsTransfer -BitsJob $bitsjob -Confirm:$false -ErrorAction Ignore
                             foreach ($file in $bitsjob.FileList.LocalName) {
                                 Write-PSFMessage -Level Verbose -Message "Oh no, $file has errored."
                                 Stop-PSFFunction -Message "Failure downloading $title (file) | $($bitsjob.ErrorDescription)" -Continue
                             }
-                            $null = $bitsjob | Complete-BitsTransfer -ErrorAction Ignore
                         }
                     }
                 } catch {
+                    $null = Remove-BitsTransfer -BitsJob $bitsjob -Confirm:$false -ErrorAction Ignore
                     Stop-PSFFunction -Message "Failure for $title | $PSItem" -Continue
                 }
             }

--- a/tests/unit/Start-BitsJobProcess.Tests.ps1
+++ b/tests/unit/Start-BitsJobProcess.Tests.ps1
@@ -10,6 +10,7 @@ Describe 'Start-BitsJobProcess PowerShell compatibility' {
             LocalName = 'C:\temp\update.msu'
         }
         $job = [pscustomobject]@{
+            JobId            = [guid]::NewGuid()
             BytesTotal       = 1024
             BytesTransferred = 0
             FileList         = $file

--- a/tests/unit/Start-BitsJobProcessLifecycle.Tests.ps1
+++ b/tests/unit/Start-BitsJobProcessLifecycle.Tests.ps1
@@ -1,0 +1,99 @@
+BeforeAll {
+    function Stop-PSFFunction { param($Message, [switch]$Continue) }
+    function Get-BitsTransfer { }
+    function Complete-BitsTransfer { param($BitsJob) }
+    function Resume-BitsTransfer { param($BitsJob, [switch]$Asynchronous) }
+    function Remove-BitsTransfer { param($BitsJob, [switch]$Confirm) }
+
+    . (Join-Path $PSScriptRoot '../../private/Start-BitsJobProcess.ps1')
+}
+
+Describe 'Start-BitsJobProcess job lifecycle' {
+    BeforeEach {
+        Mock Write-PSFMessage
+        Mock Write-Progress
+        Mock Start-Sleep
+        Mock Get-ChildItem { @() }
+        Mock Complete-BitsTransfer
+        Mock Resume-BitsTransfer
+        Mock Remove-BitsTransfer
+        Mock Stop-PSFFunction
+    }
+
+    It 'removes one current error job without processing an unrelated stale job' {
+        $fileList = [pscustomobject]@{
+            Count     = 1
+            LocalName = @('C:\temp\current.msu')
+        }
+        $testJob = [pscustomobject]@{
+            JobId            = [guid]::NewGuid()
+            FileList         = $fileList
+            BytesTotal       = 1024
+            BytesTransferred = 0
+            Description      = 'kbupdate - current update'
+            JobState         = 'Error'
+            ErrorDescription = 'file not found'
+        }
+
+        $staleJob = [pscustomobject]@{
+            JobId            = [guid]::NewGuid()
+            FileList         = $fileList
+            BytesTotal       = 1024
+            BytesTransferred = 0
+            Description      = 'kbupdate - stale update'
+            JobState         = 'Error'
+        }
+
+        $script:pollCount = 0
+        Mock Get-BitsTransfer {
+            $script:pollCount++
+            if ($script:pollCount -eq 1) {
+                @($testJob, $staleJob)
+            } else {
+                @()
+            }
+        }
+
+        $testJob | Start-BitsJobProcess
+
+        Should -Invoke Remove-BitsTransfer -Times 1 -ParameterFilter {
+            $BitsJob.JobId -eq $testJob.JobId
+        }
+        Should -Invoke Remove-BitsTransfer -Times 0 -ParameterFilter {
+            $BitsJob.JobId -eq $staleJob.JobId
+        }
+    }
+
+    It 'bounds suspended job retries and removes the job after the limit' {
+        $fileList = [pscustomobject]@{
+            Count     = 1
+            LocalName = @('C:\temp\suspended.msu')
+        }
+        $testJob = [pscustomobject]@{
+            JobId            = [guid]::NewGuid()
+            FileList         = $fileList
+            BytesTotal       = 1024
+            BytesTransferred = 0
+            Description      = 'kbupdate - suspended update'
+            JobState         = 'Suspended'
+        }
+
+        $script:pollCount = 0
+        Mock Get-BitsTransfer {
+            $script:pollCount++
+            if ($script:pollCount -le 3) {
+                $testJob
+            } else {
+                @()
+            }
+        }
+
+        $testJob | Start-BitsJobProcess
+
+        Should -Invoke Resume-BitsTransfer -Times 2
+        Should -Invoke Remove-BitsTransfer -Times 1
+        Should -Invoke Stop-PSFFunction -Times 1 -ParameterFilter {
+            $Message -match 'after 3 retries'
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- polls only the BITS job IDs created by the current Save-KbUpdate invocation
- removes Error and Cancelled jobs instead of trying to complete them
- bounds Suspended and TransientError retries at three attempts
- removes failed jobs before reporting or throwing
- adds regression tests for stale historical jobs and bounded retries

## Root cause

Start-BitsJobProcess selected every historical job whose description matched kbupdate. An interrupted download could therefore be rediscovered by later runs. Jobs in the Error state were passed to Complete-BitsTransfer, which does not remove a failed job, so the polling loop could report the same failure indefinitely.

## Validation

- targeted lifecycle and compatibility tests: 4 passed
- ./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap: 24 passed
- ./build/Invoke-KbUpdateIntegration.ps1 -IncludeDownloads: 7 passed, 1 mutation test skipped
- real controller-side BITS failure-state probe: job reached Error and was removed

Closes #225