### PR TITLE
Preserve offline scan download identity

### DIFF
--- a/private/Get-Needed.ps1
+++ b/private/Get-Needed.ps1
@@ -65,6 +65,12 @@ function Get-Needed {
                 # iterate the updates in searchresult
                 # it must be force iterated like this
                 $links = @()
+                foreach ($file in $wsuskb.DownloadContents) {
+                    if ($file.DownloadUrl) {
+                        $links += $file.DownloadUrl.Replace("http://download.windowsupdate.com", "https://catalog.s.download.windowsupdate.com")
+                    }
+                }
+
                 foreach ($bundle in $wsuskb.BundledUpdates) {
                     foreach ($file in $bundle.DownloadContents) {
                         if ($file.DownloadUrl) {
@@ -73,6 +79,7 @@ function Get-Needed {
                     }
                 }
 
+                $links = @($links | Select-Object -Unique)
                 [pscustomobject]@{
                     ComputerName      = $Computer
                     Title             = $wsuskb.Title

--- a/private/Resolve-KbNeededUpdateLink.ps1
+++ b/private/Resolve-KbNeededUpdateLink.ps1
@@ -1,0 +1,40 @@
+function Resolve-KbNeededUpdateLink {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [pscustomobject]$InputObject,
+        [pscredential]$Credential
+    )
+    process {
+        $result = $InputObject
+        if (-not $result.Link -and $result.KBUpdate) {
+            if ($result.UpdateId) {
+                $lookupPattern = $result.UpdateId
+            } else {
+                $lookupPattern = $result.KBUpdate.Trim()
+            }
+            Write-PSFMessage -Level Verbose -Message "No link found for $lookupPattern. Looking it up."
+            $lookupParameters = @{
+                Pattern      = $lookupPattern
+                Simple       = $true
+                ComputerName = $result.ComputerName
+                Credential   = $Credential
+            }
+            $lookupResult = @(Get-KbUpdate @lookupParameters)
+            if ($result.UpdateId) {
+                $lookupResult = @($lookupResult | Where-Object UpdateId -eq $result.UpdateId)
+            } else {
+                $lookupResult = @($lookupResult | Where-Object Title -Match $result.KBUpdate)
+            }
+            $link = @(
+                $lookupResult.Link |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace([string]$PSItem) } |
+                    Select-Object -Unique
+            )
+            if ($link) {
+                $result.Link = $link
+            }
+        }
+        $result
+    }
+}

--- a/public/Get-KbNeededUpdate.ps1
+++ b/public/Get-KbNeededUpdate.ps1
@@ -62,6 +62,11 @@ function Get-KbNeededUpdate {
         PS C:\> Get-KbNeededUpdate | Save-KbUpdate -Path C:\temp
 
         Saves all the updates needed on the local machine to C:\temp
+
+    .EXAMPLE
+        PS C:\> Get-KbNeededUpdate -ScanFilePath D:\wsusscn2.cab | Export-Clixml D:\needed-updates.clixml
+
+        Exports the exact update identities and download links found on an offline computer. Move the CLIXML file to an internet-connected computer and pipe Import-Clixml to Save-KbUpdate.
 #>
     [CmdletBinding(DefaultParameterSetName = 'UseWUA')]
     param(
@@ -212,21 +217,7 @@ function Get-KbNeededUpdate {
         if ($jobs.Name) {
             try {
                 foreach ($result in ($jobs | Start-JobProcess -Activity "Getting needed updates" -Status "getting needed updates" | Select-Object -Property * -ExcludeProperty PSComputerName, RunspaceId | Select-DefaultView -ExcludeProperty InstallFile | Select-DefaultView -Property ComputerName, Title, KBUpdate, UpdateId, Description, LastModified, RebootBehavior, RequestsUserInput, NetworkRequired, Link)) {
-                    if (-not $result.Link -and $result.KBUpdate) {
-                        Write-PSFMessage -Level Verbose -Message "No link found for $($result.KBUpdate.Trim()). Looking it up."
-                        $lookupParameters = @{
-                            Pattern      = $result.KBUpdate.Trim()
-                            Simple       = $true
-                            ComputerName = $result.ComputerName
-                            Credential   = $Credential
-                        }
-                        $link = (Get-KbUpdate @lookupParameters |
-                                Where-Object Title -Match $result.KBUpdate).Link
-                        if ($link) {
-                            $result.Link = $link
-                        }
-                    }
-                    $result
+                    $result | Resolve-KbNeededUpdateLink -Credential $Credential
                 }
             } catch {
                 Stop-PSFFunction -Message "Failure" -ErrorRecord $PSItem -EnableException:$EnableException -Continue

--- a/public/Save-KbUpdate.ps1
+++ b/public/Save-KbUpdate.ps1
@@ -34,7 +34,9 @@ function Save-KbUpdate {
         Search source. By default, Database is searched first, then if no matches are found, it tries finding it on the web if a an internet connection is detected.
 
     .PARAMETER InputObject
-        Enables piping from Get-KbUpdate
+        Enables piping update objects from Get-KbUpdate, Get-KbNeededUpdate, or Import-Clixml.
+
+        Links already present on a piped object are downloaded directly so the exact update artifact selected by an offline scan is preserved.
 
     .PARAMETER AllowClobber
         Overwrite file if it exsits
@@ -82,12 +84,17 @@ function Save-KbUpdate {
         PS C:\> Save-KBUpdate -Link $downloadLink -Path C:\temp
 
         Downloads all files from $downloadLink to C:\temp
+
+    .EXAMPLE
+        PS C:\> Import-Clixml E:\needed-updates.clixml | Save-KbUpdate -Path E:\updates
+
+        Downloads the exact update links exported by Get-KbNeededUpdate on an offline computer.
     #>
     [CmdletBinding(DefaultParameterSetName = 'default', SupportsShouldProcess, ConfirmImpact = 'Low')]
     param(
         [Parameter(Mandatory, ParameterSetName = 'link')]
         [string[]]$Link,
-        [Parameter(ValueFromPipelineByPropertyName, Position = 0)]
+        [Parameter(Position = 0)]
         [Alias("UpdateId", "Id", "KBUpdate", "HotfixId", "Name")]
         [string[]]$Pattern,
         [string]$Path = ".",
@@ -106,6 +113,10 @@ function Save-KbUpdate {
     )
     begin {
         $jobs = $inputobjects = $uniquelinks = @()
+        $requestedPatterns = @(
+            $Pattern |
+                Where-Object { -not [string]::IsNullOrWhiteSpace([string]$PSItem) }
+        )
         $count = 0
     }
     process {
@@ -197,12 +208,12 @@ function Save-KbUpdate {
 
             default {
                 Write-PSFMessage -Level Verbose -Message "Processing default parameter set"
-                if ($Pattern.Count -gt 1 -and $PSBoundParameters.FilePath) {
+                if ($requestedPatterns.Count -gt 1 -and $PSBoundParameters.FilePath) {
                     Stop-PSFFunction -EnableException:$EnableException -Message "You can only specify one KB when using FilePath"
                     return
                 }
 
-                if (-not $PSBoundParameters.InputObject -and -not $PSBoundParameters.Pattern) {
+                if (-not $inputobjects -and -not $requestedPatterns) {
                     Stop-PSFFunction -EnableException:$EnableException -Message "You must specify a KB name or pipe in results from Get-KbUpdate"
                     return
                 }
@@ -214,7 +225,7 @@ function Save-KbUpdate {
 
                 Write-PSFMessage -Level Verbose -Message "Source set to $Source"
 
-                foreach ($kb in $Pattern) {
+                foreach ($kb in $requestedPatterns) {
                     if ($Latest) {
                         $simple = $false
                     } else {
@@ -238,7 +249,6 @@ function Save-KbUpdate {
                     $inputobjects += Get-KbUpdate @params
                 }
 
-                $inputobjects = $inputobjects | Sort-Object -Unique
 
                 if ($Architecture) {
                     foreach ($object in $inputobjects) {
@@ -267,16 +277,43 @@ function Save-KbUpdate {
                 $allDownloadLinks = @(
                     $inputobjects |
                         ForEach-Object { $PSItem.Link } |
-                        Where-Object { $PSItem } |
+                        Where-Object { -not [string]::IsNullOrWhiteSpace([string]$PSItem) } |
                         Select-Object -Unique
                 )
                 if ($PSBoundParameters.FilePath -and $allDownloadLinks.Count -gt 1) {
                     Stop-PSFFunction -EnableException:$EnableException -Message 'You can only specify FilePath when downloading one unique link'
                     return
                 }
+                $processedLinks = @{}
 
                 foreach ($object in $inputobjects) {
-                    foreach ($hyperlinklol in @($object.Link)) {
+                    $objectLinks = @(
+                        $object.Link |
+                            Where-Object { -not [string]::IsNullOrWhiteSpace([string]$PSItem) } |
+                            Select-Object -Unique
+                    )
+                    if (-not $objectLinks) {
+                        $identity = $object.UpdateId
+                        if (-not $identity) {
+                            $identity = $object.KBUpdate
+                        }
+                        if (-not $identity) {
+                            $identity = $object.Title
+                        }
+                        if (-not $identity) {
+                            $identity = 'input object'
+                        }
+                        Write-PSFMessage -Level Warning -Message "No download link was provided for $identity. Skipping."
+                        continue
+                    }
+
+                    foreach ($hyperlinklol in $objectLinks) {
+                        $linkKey = [string]$hyperlinklol
+                        if ($processedLinks.ContainsKey($linkKey)) {
+                            continue
+                        }
+                        $processedLinks[$linkKey] = $true
+
                         $title = $object.Title
                         if (-not $PSBoundParameters.FilePath) {
                             $downloadFileName = Split-Path -Path $hyperlinklol -Leaf

--- a/tests/integration/Catalog.Integration.Tests.ps1
+++ b/tests/integration/Catalog.Integration.Tests.ps1
@@ -60,5 +60,28 @@ Describe 'Live Microsoft Update Catalog' -Tag 'Integration', 'Catalog' {
             $file.Length | Should -BeGreaterThan 0
         }
     }
+
+    It 'preserves exact links through a CLIXML handoff when downloading' -Skip:(-not $context.IncludeDownloads) {
+        $targetPath = Join-Path $context.DownloadPath 'clixml-handoff'
+        $null = New-Item -ItemType Directory -Path $targetPath -Force
+        $handoffPath = Join-Path $targetPath 'needed-updates.clixml'
+        $update = Get-KbUpdate -Name KB2992080 -Source Web -Simple -EnableException |
+            Select-Object -First 1
+        $update | Export-Clixml -Path $handoffPath
+        $restoredUpdate = Import-Clixml -Path $handoffPath
+        $expectedFileNames = @(
+            $restoredUpdate.Link |
+                Where-Object { $PSItem } |
+                ForEach-Object { Split-Path -Path $PSItem -Leaf } |
+                Sort-Object -Unique
+        )
+
+        $result = @($restoredUpdate | Save-KbUpdate -Path $targetPath -AllowClobber -Confirm:$false -EnableException)
+        $actualFileNames = @($result.Name | Sort-Object -Unique)
+
+        $actualFileNames.Count | Should -BeGreaterThan 0
+        Compare-Object -ReferenceObject $expectedFileNames -DifferenceObject $actualFileNames |
+            Should -BeNullOrEmpty
+    }
 }
 

--- a/tests/unit/Resolve-KbNeededUpdateLink.Tests.ps1
+++ b/tests/unit/Resolve-KbNeededUpdateLink.Tests.ps1
@@ -1,0 +1,84 @@
+BeforeAll {
+    function Get-KbUpdate { param($Pattern, $Simple, $ComputerName, $Credential) }
+    function Write-PSFMessage { }
+    . (Join-Path $PSScriptRoot '../../private/Resolve-KbNeededUpdateLink.ps1')
+}
+
+Describe 'Resolve-KbNeededUpdateLink' {
+    BeforeEach {
+        Mock Write-PSFMessage
+    }
+
+    It 'looks up and selects links by exact UpdateId' {
+        $updateId = 'abfafad8-5378-48df-a64f-deedc7de0f5a'
+        $exactLink = 'https://catalog.s.download.windowsupdate.com/test/exact.cab'
+        Mock Get-KbUpdate {
+            @(
+                [pscustomobject]@{
+                    Title    = 'KB5048652 alternate artifact'
+                    UpdateId = '99999999-9999-9999-9999-999999999999'
+                    Link     = 'https://catalog.s.download.windowsupdate.com/test/alternate.msu'
+                }
+                [pscustomobject]@{
+                    Title    = 'KB5048652 exact artifact'
+                    UpdateId = $updateId
+                    Link     = @($exactLink, $null)
+                }
+            )
+        }
+        $neededUpdate = [pscustomobject]@{
+            ComputerName = 'offline-host'
+            Title        = 'KB5048652 needed update'
+            KBUpdate     = 'KB5048652'
+            UpdateId     = $updateId
+            Link         = $null
+        }
+
+        $result = $neededUpdate | Resolve-KbNeededUpdateLink
+
+        $result.Link | Should -Be @($exactLink)
+        Should -Invoke Get-KbUpdate -Times 1 -Exactly -ParameterFilter {
+            $Pattern -eq $updateId -and $ComputerName -eq 'offline-host'
+        }
+    }
+
+    It 'leaves an existing scan link unchanged without a lookup' {
+        Mock Get-KbUpdate
+        $exactLink = 'https://catalog.s.download.windowsupdate.com/test/from-scan.cab'
+        $neededUpdate = [pscustomobject]@{
+            ComputerName = 'offline-host'
+            Title        = 'KB5048652 needed update'
+            KBUpdate     = 'KB5048652'
+            UpdateId     = 'abfafad8-5378-48df-a64f-deedc7de0f5a'
+            Link         = $exactLink
+        }
+
+        $result = $neededUpdate | Resolve-KbNeededUpdateLink
+
+        $result.Link | Should -Be $exactLink
+        Should -Invoke Get-KbUpdate -Times 0 -Exactly
+    }
+
+    It 'falls back to the KB identity when UpdateId is unavailable' {
+        Mock Get-KbUpdate {
+            [pscustomobject]@{
+                Title    = 'Security update KB5000004'
+                UpdateId = '44444444-4444-4444-4444-444444444444'
+                Link     = 'https://catalog.s.download.windowsupdate.com/test/kb-fallback.msu'
+            }
+        }
+        $neededUpdate = [pscustomobject]@{
+            ComputerName = 'offline-host'
+            Title        = 'Security update KB5000004'
+            KBUpdate     = 'KB5000004'
+            Link         = $null
+        }
+
+        $result = $neededUpdate | Resolve-KbNeededUpdateLink
+
+        $result.Link | Should -Match 'kb-fallback\.msu$'
+        Should -Invoke Get-KbUpdate -Times 1 -Exactly -ParameterFilter {
+            $Pattern -eq 'KB5000004'
+        }
+    }
+}

--- a/tests/unit/Save-KbUpdate.Tests.ps1
+++ b/tests/unit/Save-KbUpdate.Tests.ps1
@@ -58,5 +58,77 @@ Describe 'Save-KbUpdate download handling' {
                 $Path -eq 'C:\Temp\kbupdate-tests\fallback.msu'
             }
         }
+
+        It 'downloads the exact link from a serialized needed-update object without re-querying it' {
+            Mock Get-Command { $null }
+            Mock Get-KbUpdate
+            Mock Invoke-TlsWebRequest
+
+            $exactLink = 'https://catalog.s.download.windowsupdate.com/test/exact-offline-scan.cab'
+            $update = [pscustomobject]@{
+                Title      = 'Exact offline scan update'
+                KBUpdate   = 'KB5048652'
+                UpdateId   = 'abfafad8-5378-48df-a64f-deedc7de0f5a'
+                Link       = $exactLink
+            }
+            $serialized = [Management.Automation.PSSerializer]::Serialize($update)
+            $restored = [Management.Automation.PSSerializer]::Deserialize($serialized)
+
+            $null = $restored | Save-KbUpdate -Path $TestDrive -Confirm:$false
+
+            Should -Invoke Get-KbUpdate -Times 0 -Exactly
+            Should -Invoke Invoke-TlsWebRequest -Times 1 -Exactly
+        }
+
+        It 'skips null links and continues downloading valid objects in the same pipeline' {
+            Mock Get-Command { $null }
+            Mock Get-KbUpdate
+            Mock Invoke-TlsWebRequest
+            Mock Write-PSFMessage
+
+            $validLink = 'https://catalog.s.download.windowsupdate.com/test/valid-after-null.msu'
+            $updates = @(
+                [pscustomobject]@{
+                    Title    = 'Missing link update'
+                    KBUpdate = 'KB5000001'
+                    UpdateId = '11111111-1111-1111-1111-111111111111'
+                    Link     = $null
+                }
+                [pscustomobject]@{
+                    Title    = 'Valid link update'
+                    KBUpdate = 'KB5000002'
+                    UpdateId = '22222222-2222-2222-2222-222222222222'
+                    Link     = $validLink
+                }
+            )
+
+            $null = $updates | Save-KbUpdate -Path $TestDrive -Confirm:$false
+
+            Should -Invoke Get-KbUpdate -Times 0 -Exactly
+            Should -Invoke Invoke-TlsWebRequest -Times 1 -Exactly
+            Should -Invoke Write-PSFMessage -Times 1 -Exactly -ParameterFilter {
+                $Message -match '11111111-1111-1111-1111-111111111111' -and
+                    $Message -match 'Skipping'
+            }
+        }
+
+        It 'still resolves an explicitly supplied pattern' {
+            Mock Get-Command { $null }
+            Mock Get-KbUpdate {
+                [pscustomobject]@{
+                    Title    = 'Explicit pattern update'
+                    UpdateId = '33333333-3333-3333-3333-333333333333'
+                    Link     = 'https://catalog.s.download.windowsupdate.com/test/explicit-pattern.msu'
+                }
+            }
+            Mock Invoke-TlsWebRequest
+
+            $null = Save-KbUpdate -Pattern KB5000003 -Path $TestDrive -Confirm:$false
+
+            Should -Invoke Get-KbUpdate -Times 1 -Exactly -ParameterFilter {
+                $Pattern -eq 'KB5000003'
+            }
+            Should -Invoke Invoke-TlsWebRequest -Times 1 -Exactly
+        }
     }
 }

--- a/tests/unit/Save-KbUpdate.Tests.ps1
+++ b/tests/unit/Save-KbUpdate.Tests.ps1
@@ -5,6 +5,10 @@ BeforeAll {
 
 Describe 'Save-KbUpdate download handling' {
     InModuleScope kbupdate {
+        BeforeAll {
+            function Get-BitsTransfer { }
+        }
+
         BeforeEach {
             Mock Test-Path { $false }
             Mock Get-Command { [pscustomobject]@{ Name = 'Start-BitsTransfer' } }


### PR DESCRIPTION
## What changed

- preserves direct WUA download URLs from both update-level and bundled content
- exports and imports needed-update results through CLIXML without re-querying or changing the selected artifact
- skips null or blank links while continuing the rest of a batch
- preserves distinct scan records and deduplicates downloads by URL
- limits missing-link enrichment to an exact UpdateId when one is available
- documents the offline scan-to-online-download handoff

## Root cause

Save-KbUpdate bound a piped update both as InputObject and, through the UpdateId alias, as Pattern. It then queried the Catalog again, which could add a different artifact for the same KB. Sort-Object -Unique could also collapse distinct PSCustomObject records, while null links reached the download loop.

Get-KbNeededUpdate only collected BundledUpdates download content. Direct WUA updates therefore had empty link collections, and WUA applicability IDs do not necessarily match Microsoft Catalog result IDs. Reading direct DownloadContents preserves the exact file identity chosen by WUA.

## Validation

- ./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap: 30 passed
- ./build/Invoke-KbUpdateIntegration.ps1 -IncludeDownloads: 8 passed, 1 mutation test skipped
- read-only workstation lab suite with needed-update scan: 9 passed, 3 download/mutation tests skipped
- live CLIXML handoff downloaded the exact Microsoft-hosted fixture link
- live workstation WUA scan returned links for every needed KB

Closes #238