### PR TITLE
Stage UNC scan files before WUA registration

### DIFF
--- a/private/Resolve-KbScanFilePath.ps1
+++ b/private/Resolve-KbScanFilePath.ps1
@@ -1,0 +1,63 @@
+function Resolve-KbScanFilePath {
+    [CmdletBinding()]
+    param(
+        [string]$ScanFilePath,
+        [Parameter(Mandatory)]
+        $ComputerName,
+        [pscredential]$Credential,
+        [switch]$Force
+    )
+
+    if (-not $ScanFilePath) {
+        return $ScanFilePath
+    }
+
+    $isUncPath = $ScanFilePath.StartsWith('\\')
+    $shouldStage = $isUncPath -or ($Force -and -not $ComputerName.IsLocalHost)
+    if (-not $shouldStage) {
+        return $ScanFilePath
+    }
+
+    $sourceFile = Get-Item -LiteralPath $ScanFilePath -ErrorAction Stop
+    $computer = $ComputerName.ComputerName
+    if ($ComputerName.IsLocalHost) {
+        $tempPath = [IO.Path]::GetTempPath()
+    } else {
+        $tempPath = Invoke-PSFCommand -Computer $computer -Credential $Credential -ErrorAction Stop -ScriptBlock {
+            [IO.Path]::GetTempPath()
+        }
+    }
+
+    $destinationPath = Join-Path -Path $tempPath -ChildPath $sourceFile.Name
+    if ($ComputerName.IsLocalHost) {
+        $existingFile = Get-Item -LiteralPath $destinationPath -ErrorAction Ignore
+        if (-not $existingFile -or $existingFile.Length -ne $sourceFile.Length) {
+            Write-PSFMessage -Level Verbose -Message "Copying $ScanFilePath to $destinationPath"
+            $null = Copy-Item -LiteralPath $ScanFilePath -Destination $destinationPath -Force -ErrorAction Stop
+        } else {
+            Write-PSFMessage -Level Verbose -Message "$destinationPath already matches the source size. Skipping copy."
+        }
+        return $destinationPath
+    }
+
+    $existingFile = Invoke-PSFCommand -Computer $computer -Credential $Credential -ArgumentList $destinationPath -ErrorAction Stop -ScriptBlock {
+        Get-Item -LiteralPath $args -ErrorAction Ignore
+    }
+    if ($existingFile -and $existingFile.Length -eq $sourceFile.Length) {
+        Write-PSFMessage -Level Verbose -Message "$destinationPath already matches the source size on $computer. Skipping copy."
+        return $destinationPath
+    }
+
+    $remoteSession = Get-PSSession | Where-Object Name -eq "kbupdate-$computer"
+    if (-not $remoteSession) {
+        $null = Invoke-KbCommand -ComputerName $computer -Credential $Credential -ScriptBlock { Get-ChildItem }
+        $remoteSession = Get-PSSession | Where-Object Name -eq "kbupdate-$computer"
+    }
+    if (-not $remoteSession) {
+        throw "Session for $computer cannot be found or no runspaces are available."
+    }
+
+    Write-PSFMessage -Level Verbose -Message "Copying $ScanFilePath to $destinationPath on $computer"
+    $null = Copy-Item -LiteralPath $ScanFilePath -Destination $tempPath -ToSession $remoteSession -Force -ErrorAction Stop
+    $destinationPath
+}

--- a/public/Get-KbNeededUpdate.ps1
+++ b/public/Get-KbNeededUpdate.ps1
@@ -28,10 +28,10 @@ function Get-KbNeededUpdate {
 
         This optional parameter will force the command to use a local update database instead of WSUS or Windows Update.
 
-        The scan file catalog/database can be downloaded using Save-KbScanFile from an internet-connected computer.
+        The scan file catalog/database can be downloaded using Save-KbScanFile from an internet-connected computer. UNC paths are staged automatically in the target computer's temporary directory because WUA requires a local path. A cached file with the same name and size is reused.
 
     .PARAMETER Force
-        Force will copies the scan file to a temporary directory on the remote system if required.
+        Copies a controller-local scan file to a temporary directory on a remote target. UNC scan files are staged automatically and do not require Force.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -57,6 +57,11 @@ function Get-KbNeededUpdate {
         PS C:\> Get-KbNeededUpdate -ComputerName server01 -ScanFilePath $scanfile | Install-KbUpdate
 
         Installs needed updates on server01
+
+    .EXAMPLE
+        PS C:\> Get-KbNeededUpdate -ComputerName server01 -ScanFilePath \\fileserver\updates\wsusscn2.cab
+
+        Stages the UNC scan file in server01's temporary directory when needed, then scans with the target-local copy.
 
     .EXAMPLE
         PS C:\> Get-KbNeededUpdate | Save-KbUpdate -Path C:\temp
@@ -91,19 +96,23 @@ function Get-KbNeededUpdate {
             return
         }
         foreach ($computer in $ComputerName) {
-            if ($machine.IsLocalHost -and -not (Test-ElevationRequirement -ComputerName $computer)) {
+            if ($computer.IsLocalHost -and -not (Test-ElevationRequirement -ComputerName $computer)) {
                 continue
             }
 
             try {
                 Write-PSFMessage -Level Verbose -Message "Adding job for $computer"
+                if ($ScanFilePath -and -not $UseWindowsUpdate) {
+                    $cabPath = Resolve-KbScanFilePath -ScanFilePath $ScanFilePath -ComputerName $computer -Credential $Credential -Force:$Force
+                } else {
+                    $cabPath = $ScanFilePath
+                }
                 $arglist = [pscustomobject]@{
                     ComputerName     = $computer
                     Credential       = $Credential
                     UseWindowsUpdate = $UseWindowsUpdate
-                    ScanFilePath     = $ScanFilePath
+                    ScanFilePath     = $cabPath
                     EnableException  = $EnableException
-                    Force            = $Force
                     ScriptBlock      = $remotescriptblock
                     ModulePath       = $script:dependencies
                 }
@@ -119,53 +128,10 @@ function Get-KbNeededUpdate {
                     $UseWindowsUpdate = $args.UseWindowsUpdate
                     $ScanFilePath     = $args.ScanFilePath
                     $EnableException  = $args.EnableException
-                    $Force            = $args.Force
                     $ScriptBlock      = $sb
 
                     $computer = $machine.ComputerName
                     $null = $completed++
-
-                    if ($ScanFilePath -and $Force -and -not $machine.IsLocalhost -and -not $UseWindowsUpdate) {
-                        Write-PSFMessage -Level Verbose -Message "Initializing remote session to $computer and getting the path to the temp directory"
-
-                        $scanfile = Get-ChildItem -Path $ScanFilePath
-                        $temp = Invoke-PSFCommand -Computer $computer -Credential $Credential -ErrorAction Stop -ScriptBlock {
-                            [system.io.path]::GetTempPath()
-                        }
-                        $filename = Split-Path -Path $ScanFilePath -Leaf
-                        $cabpath = Join-PSFPath -Path $temp -Child $filename
-
-                        Write-PSFMessage -Level Verbose -Message "Checking to see if $cabpath already exists on $computer"
-
-                        $exists = Invoke-PSFCommand -Computer $computer -Credential $Credential -ArgumentList $cabpath -ErrorAction Stop -ScriptBlock {
-                            Get-ChildItem -Path $args -ErrorAction Ignore
-                        }
-
-                        if ($exists.BaseName -and $scanfile.Length -eq $exists.Length) {
-                            Write-PSFMessage -Level Verbose -Message "File exists and is of the same size. Skipping copy"
-                        } else {
-                            Write-PSFMessage -Level Verbose -Message "File does not exist"
-                            if ($Credential) {
-                                $PSDefaultParameterValues["*:Credential"] = $Credential
-                            }
-
-                            $remotesession = Get-PSSession | Where-Object Name -eq "kbupdate-$computer"
-
-                            if (-not $remotesession) {
-                                $remotesession = Invoke-KbCommand -ComputerName $computer -ScriptBlock { Get-ChildItem }
-                                $remotesession = Get-PSSession | Where-Object Name -eq "kbupdate-$computer"
-                            }
-
-                            if (-not $remotesession) {
-                                Stop-PSFFunction -EnableException:$EnableException -Message "Session for $computer can't be found or no runspaces are available. Please file an issue on the GitHub repo at https://github.com/potatoqualitee/kbupdate/issues" -Continue
-                            }
-
-                            Write-PSFMessage -Level Verbose -Message "Copying $ScanFilePath to $temp on $computer"
-                            $null = Copy-Item -Path $ScanFilePath -Destination $temp -ToSession $remotesession -Force
-                        }
-                    } else {
-                        $cabpath = $ScanFilePath
-                    }
 
                     function Test-ElevationRequirement {
                         [CmdletBinding(DefaultParameterSetName = 'Stop')]

--- a/tests/unit/Resolve-KbScanFilePath.Tests.ps1
+++ b/tests/unit/Resolve-KbScanFilePath.Tests.ps1
@@ -1,0 +1,94 @@
+BeforeAll {
+    function Invoke-PSFCommand { param($Computer, $Credential, $ArgumentList, $ScriptBlock) }
+    function Write-PSFMessage { }
+    . (Join-Path $PSScriptRoot '../../private/Resolve-KbScanFilePath.ps1')
+}
+
+Describe 'Resolve-KbScanFilePath' {
+    BeforeEach {
+        Mock Write-PSFMessage
+        Mock Copy-Item
+    }
+
+    It 'stages a UNC scan file locally without requiring Force' {
+        $sourcePath = '\\fileserver\updates\wsusscn2.cab'
+        $destinationPath = Join-Path ([IO.Path]::GetTempPath()) 'wsusscn2.cab'
+        $computer = [pscustomobject]@{
+            ComputerName = 'localhost'
+            IsLocalHost  = $true
+        }
+        Mock Get-Item {
+            if ($LiteralPath -eq $sourcePath) {
+                [pscustomobject]@{ Name = 'wsusscn2.cab'; Length = 100 }
+            }
+        }
+
+        $result = Resolve-KbScanFilePath -ScanFilePath $sourcePath -ComputerName $computer
+
+        $result | Should -Be $destinationPath
+        Should -Invoke Copy-Item -Times 1 -Exactly -ParameterFilter {
+            $LiteralPath -eq $sourcePath -and $Destination -eq $destinationPath -and $Force
+        }
+    }
+
+    It 'reuses a matching local staged file' {
+        $sourcePath = '\\fileserver\updates\wsusscn2.cab'
+        $destinationPath = Join-Path ([IO.Path]::GetTempPath()) 'wsusscn2.cab'
+        $computer = [pscustomobject]@{
+            ComputerName = 'localhost'
+            IsLocalHost  = $true
+        }
+        Mock Get-Item {
+            if ($LiteralPath -eq $sourcePath) {
+                [pscustomobject]@{ Name = 'wsusscn2.cab'; Length = 100 }
+            } elseif ($LiteralPath -eq $destinationPath) {
+                [pscustomobject]@{ Name = 'wsusscn2.cab'; Length = 100 }
+            }
+        }
+
+        $result = Resolve-KbScanFilePath -ScanFilePath $sourcePath -ComputerName $computer
+
+        $result | Should -Be $destinationPath
+        Should -Invoke Copy-Item -Times 0 -Exactly
+    }
+
+    It 'resolves a cached remote UNC file without requiring Force' {
+        $sourcePath = '\\fileserver\updates\wsusscn2.cab'
+        $destinationPath = Join-Path '/tmp' 'wsusscn2.cab'
+        $computer = [pscustomobject]@{
+            ComputerName = 'remote-host'
+            IsLocalHost  = $false
+        }
+        Mock Get-Item {
+            [pscustomobject]@{ Name = 'wsusscn2.cab'; Length = 100 }
+        }
+        Mock Invoke-PSFCommand {
+            if ($ArgumentList) {
+                [pscustomobject]@{ Name = 'wsusscn2.cab'; Length = 100 }
+            } else {
+                '/tmp'
+            }
+        }
+
+        $result = Resolve-KbScanFilePath -ScanFilePath $sourcePath -ComputerName $computer
+
+        $result | Should -Be $destinationPath
+        Should -Invoke Invoke-PSFCommand -Times 2 -Exactly
+        Should -Invoke Copy-Item -Times 0 -Exactly
+    }
+
+    It 'leaves a target-local path unchanged when staging is not requested' {
+        $sourcePath = 'C:\scan\wsusscn2.cab'
+        $computer = [pscustomobject]@{
+            ComputerName = 'localhost'
+            IsLocalHost  = $true
+        }
+        Mock Get-Item
+
+        $result = Resolve-KbScanFilePath -ScanFilePath $sourcePath -ComputerName $computer
+
+        $result | Should -Be $sourcePath
+        Should -Invoke Get-Item -Times 0 -Exactly
+        Should -Invoke Copy-Item -Times 0 -Exactly
+    }
+}


### PR DESCRIPTION
## What changed

- automatically stages UNC scan CABs in the target computer temporary directory
- preserves the existing -Force behavior for controller-local files targeting remote computers
- reuses a staged file when its name and size match the source
- resolves the target-local CAB path before starting the WUA background job
- fixes the localhost elevation guard so non-elevated scans stop before copying a large CAB
- documents UNC staging and cache behavior

## Root cause

Windows Update Agent AddScanPackageService requires a local filesystem path and rejects UNC paths with HRESULT 0x8007007B even when the share is readable. The existing staging path ran only for remote targets with -Force, so localhost UNC scans and UNC scans without -Force reached WUA unchanged.

## Validation

- ./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap: 34 passed
- focused scan-path resolver tests: 4 passed
- real localhost UNC staging: source and staged SHA-256 matched
- authorized workstation offline WUA suite through the UNC CAB: 9 passed, 3 download/mutation tests skipped
- no update installation or VM operation performed

Closes #237