### PR TITLE
Fall back when Windows package providers are unavailable

### DIFF
--- a/private/Get-Software.ps1
+++ b/private/Get-Software.ps1
@@ -7,14 +7,69 @@ function Get-Software {
     $allhotfixids = New-Object System.Collections.ArrayList
     $allcbs = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\Packages'
 
-    $hasPackageManagement = [bool](Get-Command Get-Package -ErrorAction SilentlyContinue)
+    $packageProviderNames = @()
+    if ((Get-Command Get-Package -ErrorAction SilentlyContinue) -and (Get-Command Get-PackageProvider -ErrorAction SilentlyContinue)) {
+        try {
+            $availablePackageProviders = @(Get-PackageProvider -ListAvailable -ErrorAction Stop)
+            foreach ($providerName in @('msi', 'msu', 'Programs')) {
+                if ($providerName -in $availablePackageProviders.Name) {
+                    $packageProviderNames += $providerName
+                }
+            }
+        } catch {
+            Write-Verbose "PackageManagement providers are unavailable: $($PSItem.Exception.Message)"
+        }
+    }
+
+    $registryPackages = @()
+    if ('Programs' -notin $packageProviderNames) {
+        $uninstallPaths = @(
+            'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+            'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+        )
+        foreach ($uninstallPath in $uninstallPaths) {
+            $installedPrograms = Get-ItemProperty -Path $uninstallPath -ErrorAction SilentlyContinue | Where-Object DisplayName
+            foreach ($installedProgram in $installedPrograms) {
+                $registryPackages += [pscustomobject]@{
+                    Name                 = $installedProgram.DisplayName
+                    ProviderName         = 'Programs'
+                    Source               = $null
+                    Status               = 'Installed'
+                    HotfixId             = $null
+                    FullPath             = $null
+                    PackageFilename      = $null
+                    Summary              = $null
+                    FastPackageReference = $null
+                    TagId                = $null
+                    RegistryObject       = $installedProgram
+                    Meta                 = [pscustomobject]@{
+                        Attributes = @{
+                            DisplayName          = $installedProgram.DisplayName
+                            DisplayIcon          = $installedProgram.DisplayIcon
+                            UninstallString      = $installedProgram.UninstallString
+                            QuietUninstallString = $installedProgram.QuietUninstallString
+                            InstallLocation      = $installedProgram.InstallLocation
+                            EstimatedSize        = $installedProgram.EstimatedSize
+                            Publisher            = $installedProgram.Publisher
+                            VersionMajor         = $installedProgram.VersionMajor
+                            VersionMinor         = $installedProgram.VersionMinor
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     if ($pattern) {
         $packages = @()
         foreach ($name in $pattern) {
-            if ($hasPackageManagement) {
-                $packages += Get-Package -IncludeWindowsInstaller -ProviderName msi, msu, Programs -Name "*$name*" -ErrorAction SilentlyContinue
-                $packages += Get-Package -ProviderName msi, msu, Programs -Name "*$name*" -ErrorAction SilentlyContinue
+            if ($packageProviderNames) {
+                try {
+                    $packages += Get-Package -IncludeWindowsInstaller -ProviderName $packageProviderNames -Name "*$name*" -ErrorAction Stop
+                    $packages += Get-Package -ProviderName $packageProviderNames -Name "*$name*" -ErrorAction Stop
+                } catch {
+                    Write-Verbose "PackageManagement query failed: $($PSItem.Exception.Message)"
+                }
             }
             if ((Get-Service wuauserv | Where-Object StartType -ne Disabled)) {
                 $session = [type]::GetTypeFromProgID("Microsoft.Update.Session")
@@ -25,13 +80,19 @@ function Get-Software {
                     $packages += $updatesearcher.QueryHistory(0, $count) | Where-Object Name -match $Pattern
                 }
             }
+            $packages += $registryPackages | Where-Object Name -like "*$name*"
         }
     } else {
         $packages = @()
-        if ($hasPackageManagement) {
-            $packages += Get-Package -IncludeWindowsInstaller -ProviderName msi, msu, Programs
-            $packages += Get-Package -ProviderName msi, msu, Programs
+        if ($packageProviderNames) {
+            try {
+                $packages += Get-Package -IncludeWindowsInstaller -ProviderName $packageProviderNames -ErrorAction Stop
+                $packages += Get-Package -ProviderName $packageProviderNames -ErrorAction Stop
+            } catch {
+                Write-Verbose "PackageManagement query failed: $($PSItem.Exception.Message)"
+            }
         }
+        $packages += $registryPackages
         $packages = $packages | Sort-Object -Unique Name
         if ((Get-Service wuauserv | Where-Object StartType -ne Disabled)) {
             $session = [type]::GetTypeFromProgID("Microsoft.Update.Session")
@@ -61,7 +122,10 @@ function Get-Software {
         }
 
         $null = $package | Add-Member -MemberType ScriptMethod -Name ToString -Value { $this.Name } -Force
-        if (($regpath = "$($package.FastPackageReference)".Replace("hklm64\HKEY_LOCAL_MACHINE", "HKLM:\")) -match 'HKLM') {
+        if ($package.RegistryObject) {
+            $reg = $package.RegistryObject
+            $hotfixid = $null
+        } elseif (($regpath = "$($package.FastPackageReference)".Replace("hklm64\HKEY_LOCAL_MACHINE", "HKLM:\")) -match 'HKLM') {
             $reg = Get-ItemProperty -Path $regpath -ErrorAction SilentlyContinue
             $null = $reg | Add-Member -MemberType ScriptMethod -Name ToString -Value { $this.DisplayName } -Force
             $hotfixid = Split-Path -Path $regpath -Leaf | Where-Object { "$PSItem".StartsWith("KB") }

--- a/public/Get-KbInstalledSoftware.ps1
+++ b/public/Get-KbInstalledSoftware.ps1
@@ -4,7 +4,7 @@ function Get-KbInstalledSoftware {
         Tries its darndest to return all of the software installed on a system.
 
     .DESCRIPTION
-        Tries its darndest to return all of the software installed on a system. It's intended to be a replacement for Get-Hotfix, Get-Package, Windows Update results and searching CIM for install updates and programs.
+        Tries its darndest to return all of the software installed on a system. It's intended to be a replacement for Get-Hotfix, Get-Package, Windows Update results and searching CIM for install updates and programs. If the Windows PackageManagement providers are unavailable, installed programs are discovered from the uninstall registry instead.
 
     .PARAMETER Pattern
         Any pattern. But really, a KB pattern is your best bet.

--- a/tests/unit/Get-Software.Tests.ps1
+++ b/tests/unit/Get-Software.Tests.ps1
@@ -1,0 +1,46 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../private/Get-Software.ps1')
+}
+
+Describe 'Get-Software package provider fallback' {
+    BeforeEach {
+        Mock Get-ChildItem
+        Mock Get-PackageProvider { throw 'Unable to find package provider.' }
+        Mock Get-Package
+        Mock Get-Service { [pscustomobject]@{ StartType = 'Disabled' } }
+        Mock Get-CimInstance
+        Mock Get-ItemProperty {
+            if ($Path -like '*CurrentVersion\Uninstall\*') {
+                [pscustomobject]@{
+                    DisplayName     = 'Contoso PowerShell Tool'
+                    DisplayVersion  = '1.2.3'
+                    Publisher       = 'Contoso'
+                    UninstallString = 'uninstall.exe'
+                }
+                [pscustomobject]@{
+                    DisplayName     = 'Fabrikam Utility'
+                    DisplayVersion  = '4.5.6'
+                    Publisher       = 'Fabrikam'
+                    UninstallString = 'remove.exe'
+                }
+            }
+        }
+    }
+
+    It 'uses uninstall registry entries when Windows package providers are unavailable' -Skip:($env:OS -ne 'Windows_NT') {
+        $result = @(Get-Software -IncludeHidden:$false -VerbosePreference SilentlyContinue)
+
+        $result.Name | Should -Contain 'Contoso PowerShell Tool'
+        $result.Name | Should -Contain 'Fabrikam Utility'
+        ($result | Where-Object Name -eq 'Contoso PowerShell Tool').ProviderName | Should -Be 'Programs'
+        Should -Invoke Get-Package -Times 0 -Exactly
+    }
+
+    It 'filters registry fallback results by pattern' -Skip:($env:OS -ne 'Windows_NT') {
+        $result = @(Get-Software -Pattern 'PowerShell' -IncludeHidden:$false -VerbosePreference SilentlyContinue)
+
+        $result.Name | Should -Contain 'Contoso PowerShell Tool'
+        $result.Name | Should -Not -Contain 'Fabrikam Utility'
+        Should -Invoke Get-Package -Times 0 -Exactly
+    }
+}


### PR DESCRIPTION
Fixes #205. Discovers only the Windows PackageManagement providers that are actually available, falls back to the 32-bit and 64-bit uninstall registry when the Programs provider is missing, and preserves WUA, CBS, and CIM discovery. Adds regression coverage for unfiltered and pattern-filtered fallback results. Validation: the deterministic quality gate passes all 36 tests; a live read-only PowerShell 7 Get-KbInstalledSoftware query returned three matching programs with zero warnings.