### PR TITLE
Refresh BITS download totals while polling

### DIFF
--- a/private/Start-BitsJobProcess.ps1
+++ b/private/Start-BitsJobProcess.ps1
@@ -27,9 +27,11 @@ function Start-BitsJobProcess {
         $maximumRetries = 3
 
         while ($bitsjobs = @(Get-BitsTransfer | Where-Object { $PSItem.JobId -in $jobIds })) {
-            $bytesjob = $bitsjobs | Where-Object BytesTotal -ne 18446744073709551615
+            $bytesjob = @($bitsjobs | Where-Object BytesTotal -ne 18446744073709551615)
             $bjbytestotal = ($bytesjob.BytesTransferred | Measure-Object -Sum).Sum
             $mbjtotal = [math]::Round(($bjbytestotal / 1MB),2)
+            $bytestotal = ($bytesjob.BytesTotal | Measure-Object -Sum).Sum
+            $bstotal = [math]::Round(($bytestotal / 1MB),2)
 
             $currentcount = $bitsjobs.FileList.Count
             $completed = $totalfiles - $currentcount
@@ -40,7 +42,7 @@ function Start-BitsJobProcess {
             }
 
             $progressparms = @{
-                Activity        = "Downloaded $mbjtotal MB of at least $bstotal MB total from $($bs.count) files in this batch."
+                Activity        = "Downloaded $mbjtotal MB of at least $bstotal MB total from $($bytesjob.Count) files in this batch."
                 Status          = "$completed of $totalfiles files completed"
                 PercentComplete = $percentcomplete
             }
@@ -50,9 +52,6 @@ function Start-BitsJobProcess {
                 Write-PSFMessage -Level Debug -Message "$completed have been completed"
                 Write-PSFMessage -Level Debug -Message "$(($currentcount / $totalfiles) * 100) percent left"
                 $oldmbjtotal = $mbjtotal
-                $bs = $bitsjobs | Where-Object BytesTotal -ne 18446744073709551615
-                $bytestotal = ($bs.BytesTotal | Measure-Object -Sum).Sum
-                $mbjtotal = [math]::Round(($bytestotal / 1MB),2)
                 Write-Progress @progressparms
                 Start-Sleep -Seconds 1
             }

--- a/tests/unit/Start-BitsJobProcess.Tests.ps1
+++ b/tests/unit/Start-BitsJobProcess.Tests.ps1
@@ -27,4 +27,46 @@ Describe 'Start-BitsJobProcess PowerShell compatibility' {
     It 'declares InputObject using a runtime-neutral object array' {
         (Get-Command Start-BitsJobProcess).Parameters.InputObject.ParameterType | Should -Be ([object[]])
     }
+
+    It 'refreshes the displayed total after BITS discovers the file size' {
+        $jobId = [guid]::NewGuid()
+        $file = [pscustomobject]@{
+            Count     = 1
+            LocalName = 'C:\temp\update.msu'
+        }
+        $queuedJob = [pscustomobject]@{
+            JobId            = $jobId
+            BytesTotal       = [uint64]::MaxValue
+            BytesTransferred = 0
+            FileList         = $file
+        }
+        $activeJob = [pscustomobject]@{
+            JobId            = $jobId
+            BytesTotal       = 5MB
+            BytesTransferred = 2MB
+            FileList         = $file
+            Description      = 'kbupdate - test update'
+            JobState         = 'Connecting'
+        }
+
+        $script:pollCount = 0
+        Mock Get-BitsTransfer {
+            $script:pollCount++
+            if ($script:pollCount -eq 1) {
+                $activeJob
+            } else {
+                @()
+            }
+        }
+        Mock Get-ChildItem { @() }
+        Mock Write-Progress
+        Mock Write-PSFMessage
+        Mock Start-Sleep
+
+        $queuedJob | Start-BitsJobProcess
+
+        Should -Invoke Write-Progress -Times 1 -ParameterFilter {
+            $Activity -eq 'Downloaded 2 MB of at least 5 MB total from 1 files in this batch.'
+        }
+    }
 }


### PR DESCRIPTION
Fixes #214. Recalculates known total bytes from the live BITS jobs on each poll, keeps transferred bytes separate from total bytes, and reports the current count of jobs with known sizes. Adds a regression covering a job whose size starts unknown and later reports 2 MB downloaded out of 5 MB. Validation: the deterministic quality gate passes all 37 tests.