### PR TITLE
Preserve distinct latest update variants

### DIFF
--- a/public/Select-KbLatest.ps1
+++ b/public/Select-KbLatest.ps1
@@ -37,6 +37,12 @@ function Select-KbLatest {
             $otherkbs = $allkbs | Where-Object Id -ne $kb.Id
             $match += $allkbs | Where-Object { $PSItem.Id -eq $kb.Id -and $otherkbs.Supersedes.Kb -notcontains $kb.Id }
         }
-        $match | Sort-Object -Property @{Expression = "Id"; Descending = $true }, @{Expression = "LastModified"; Descending = $true } -Unique
+        $sortProperties = @(
+            @{ Expression = 'Id'; Descending = $true }
+            @{ Expression = 'LastModified'; Descending = $true }
+            @{ Expression = 'UpdateId'; Descending = $false }
+            @{ Expression = 'Link'; Descending = $false }
+        )
+        $match | Sort-Object -Property $sortProperties -Unique
     }
 }

--- a/tests/unit/Select-KbLatest.Tests.ps1
+++ b/tests/unit/Select-KbLatest.Tests.ps1
@@ -1,0 +1,44 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '../../public/Select-KbLatest.ps1')
+}
+
+Describe 'Select-KbLatest' {
+    It 'preserves distinct catalog variants with the same KB and modified date' {
+        $lastModified = [datetime]'2022-10-18'
+        $updates = @(
+            [pscustomobject]@{ Id = '5020435'; LastModified = $lastModified; UpdateId = '11111111-1111-1111-1111-111111111111'; Link = 'https://example.test/x64.msu'; Supersedes = @() }
+            [pscustomobject]@{ Id = '5020435'; LastModified = $lastModified; UpdateId = '22222222-2222-2222-2222-222222222222'; Link = 'https://example.test/x86.msu'; Supersedes = @() }
+            [pscustomobject]@{ Id = '5020435'; LastModified = $lastModified; UpdateId = '33333333-3333-3333-3333-333333333333'; Link = 'https://example.test/arm64.msu'; Supersedes = @() }
+        )
+
+        $result = @($updates | Select-KbLatest)
+
+        $result.Count | Should -Be 3
+        $result.UpdateId | Should -Be $updates.UpdateId
+    }
+
+    It 'preserves multiple download files for one catalog update' {
+        $updateId = '11111111-1111-1111-1111-111111111111'
+        $updates = @(
+            [pscustomobject]@{ Id = '5020435'; LastModified = [datetime]'2022-10-18'; UpdateId = $updateId; Link = 'https://example.test/update.cab'; Supersedes = @() }
+            [pscustomobject]@{ Id = '5020435'; LastModified = [datetime]'2022-10-18'; UpdateId = $updateId; Link = 'https://example.test/update.msu'; Supersedes = @() }
+        )
+
+        $result = @($updates | Select-KbLatest)
+
+        $result.Count | Should -Be 2
+        $result.Link | Should -Be $updates.Link
+    }
+
+    It 'removes a KB superseded by another KB in the batch' {
+        $updates = @(
+            [pscustomobject]@{ Id = '5000001'; LastModified = [datetime]'2022-09-01'; UpdateId = '11111111-1111-1111-1111-111111111111'; Link = 'https://example.test/old.msu'; Supersedes = @() }
+            [pscustomobject]@{ Id = '5000002'; LastModified = [datetime]'2022-10-01'; UpdateId = '22222222-2222-2222-2222-222222222222'; Link = 'https://example.test/new.msu'; Supersedes = @([pscustomobject]@{ KB = '5000001' }) }
+        )
+
+        $result = @($updates | Select-KbLatest)
+
+        $result.Count | Should -Be 1
+        $result.Id | Should -Be '5000002'
+    }
+}


### PR DESCRIPTION
Fixes #201. Includes UpdateId and Link in Select-KbLatest uniqueness so catalog variants sharing a KB number and LastModified date are not collapsed, while existing supersedence filtering remains intact. Adds regressions for distinct catalog variants, multiple files per update, and genuine supersedence. Validation: all 40 deterministic tests pass; the live KB5020435 catalog query preserved all 12 results and 12 distinct UpdateIds through Select-KbLatest.