### PR TITLE
Add configurable authenticated proxy support

### DIFF
--- a/kbupdate.psd1
+++ b/kbupdate.psd1
@@ -48,7 +48,9 @@
         'Select-KbLatest',
         'Save-KbScanFile',
         'Get-KbNeededUpdate',
-        'Disconnect-KbWsusServer'
+        'Disconnect-KbWsusServer',
+        'Get-KbProxy',
+        'Set-KbProxy'
     )
 
     AliasesToExport   = @('Get-KbInstalledUpdate')

--- a/kbupdate.psm1
+++ b/kbupdate.psm1
@@ -113,6 +113,10 @@ if (-not $internet) {
 # Source
 Set-PSFConfig -FullName kbupdate.app.source -Value @('Web', 'Database') -Initialize -Validation stringarray -Handler { } -Description 'Data source for Get-KbUpdate and Save-KbUpdate'
 
+# Proxy
+Set-PSFConfig -FullName kbupdate.app.proxy -Value $null -Initialize -Handler { } -Description 'Optional proxy URI for catalog lookups and downloads. When empty, the system proxy is detected automatically.'
+Set-PSFConfig -FullName kbupdate.app.proxycredential -Value $null -Initialize -Handler { } -Description 'Optional in-memory credential for authenticating to the configured or automatically detected proxy.'
+
 # Disables session caching
 Set-PSFConfig -FullName PSRemoting.Sessions.Enable -Value $true -Initialize -Validation bool -Handler { } -Description 'Globally enables session caching for PowerShell remoting'
 

--- a/private/Invoke-TlsWebRequest.ps1
+++ b/private/Invoke-TlsWebRequest.ps1
@@ -1,5 +1,34 @@
 function Invoke-TlsWebRequest {
-    $script:arrgs = $Args
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [uri]$Uri,
+        [string]$Method,
+        [object]$Body,
+        [string]$OutFile,
+        [uri]$Proxy,
+        [pscredential]$ProxyCredential
+    )
+
+    $requestParameters = @{
+        Uri = $Uri
+    }
+    foreach ($parameterName in 'Method', 'Body', 'OutFile') {
+        if ($PSBoundParameters.ContainsKey($parameterName)) {
+            $requestParameters[$parameterName] = $PSBoundParameters[$parameterName]
+        }
+    }
+
+    $effectiveProxy = $Proxy
+    if ($ProxyCredential -and -not $effectiveProxy) {
+        $systemProxy = [System.Net.WebRequest]::DefaultWebProxy
+        if ($systemProxy) {
+            $detectedProxy = $systemProxy.GetProxy($Uri)
+            if ($detectedProxy -and $detectedProxy -ne $Uri) {
+                $effectiveProxy = $detectedProxy
+            }
+        }
+    }
     $PSDefaultParameterValues["Invoke-WebRequest:UseBasicParsing"] = $true
     $PSDefaultParameterValues["Invoke-WebRequest:WebSession"] = $script:websession
     $PSDefaultParameterValues["Invoke-WebRequest:OutVariable"] = "script:previouspage"
@@ -23,11 +52,27 @@ function Invoke-TlsWebRequest {
 
     if (-not $IsLinux -and -not $IsMacOs) {
         $regproxy = Get-ItemProperty -Path "Registry::HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings"
-        $proxy = $regproxy.ProxyServer
+        $registryProxy = $regproxy.ProxyServer
 
-        if ($proxy -and -not ([System.Net.Webrequest]::DefaultWebProxy).Address -and $regproxy.ProxyEnable) {
-            [System.Net.Webrequest]::DefaultWebProxy = New-object System.Net.WebProxy $proxy
+        if ($registryProxy -and -not ([System.Net.Webrequest]::DefaultWebProxy).Address -and $regproxy.ProxyEnable) {
+            [System.Net.Webrequest]::DefaultWebProxy = New-Object System.Net.WebProxy $registryProxy
             [System.Net.Webrequest]::DefaultWebProxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+            if ($ProxyCredential -and -not $effectiveProxy) {
+                $effectiveProxy = [uri]$registryProxy
+            }
+        }
+    }
+
+    if ($ProxyCredential -and -not $effectiveProxy) {
+        throw 'No system proxy was detected. Specify Proxy when using ProxyCredential.'
+    }
+
+    if ($effectiveProxy) {
+        $requestParameters.Proxy = $effectiveProxy
+        if ($ProxyCredential) {
+            $requestParameters.ProxyCredential = $ProxyCredential
+        } else {
+            $requestParameters.ProxyUseDefaultCredentials = $true
         }
     }
 
@@ -52,17 +97,22 @@ function Invoke-TlsWebRequest {
         $Language = "en-US;q=0.5,en;q=0.3"
     }
 
-    if ($script:Maxpages -eq 1 -or $args[1] -notmatch "Search.aspx") {
-        Write-PSFMessage -Level Verbose -Message "URL: $($args[1])"
+    if ($script:Maxpages -eq 1 -or $Uri.AbsoluteUri -notmatch "Search.aspx") {
+        Write-PSFMessage -Level Verbose -Message "URL: $Uri"
         if ($script:websession -and $script:websession.Headers."Accept-Language" -eq $Language) {
-            Invoke-WebRequest @Args
+            Invoke-WebRequest @requestParameters
         } else {
-            Invoke-WebRequest @Args -SessionVariable websession -Headers @{ "Accept-Language" = $Language } -WebSession $null
+            $sessionParameters = $requestParameters.Clone()
+            $sessionParameters.SessionVariable = 'websession'
+            $sessionParameters.Headers = @{ "Accept-Language" = $Language }
+            $sessionParameters.WebSession = $null
+            Invoke-WebRequest @sessionParameters
             $script:websession = $websession
         }
     } else {
         1..$script:MaxPages | ForEach-Object -Process {
-            Write-PSFMessage -Level Verbose -Message "URL: $($arrgs[1])"
+            Write-PSFMessage -Level Verbose -Message "URL: $Uri"
+            $pageParameters = $requestParameters.Clone()
             if ($PSItem -gt 1) {
                 $body = @{
                     '__EVENTTARGET'        = 'ctl00$catalogBody$nextPageLinkText'
@@ -71,22 +121,17 @@ function Invoke-TlsWebRequest {
                     '__VIEWSTATEGENERATOR' = ($script:previouspage.InputFields | Where-Object Name -eq __VIEWSTATEGENERATOR).Value
                     '__EVENTVALIDATION'    = ($script:previouspage.InputFields | Where-Object Name -eq __EVENTVALIDATION).Value
                 }
-                $pages = @{
-                    Body   = $body
-                    Method = "POST"
-                }
-            } else {
-                $pages = @{}
+                $pageParameters.Body = $body
+                $pageParameters.Method = "POST"
             }
 
             if ($script:websession -and $script:websession.Headers."Accept-Language" -eq $Language) {
-                if ($pages -and $arrgs[3] -ne "POST") {
-                    Invoke-WebRequest @arrgs @pages
-                } else {
-                    Invoke-WebRequest @arrgs
-                }
+                Invoke-WebRequest @pageParameters
             } else {
-                Invoke-WebRequest @arrgs -SessionVariable websession -Headers @{ "Accept-Language" = $Language } -WebSession $null
+                $pageParameters.SessionVariable = 'websession'
+                $pageParameters.Headers = @{ "Accept-Language" = $Language }
+                $pageParameters.WebSession = $null
+                Invoke-WebRequest @pageParameters
                 $script:websession = $websession
             }
         }

--- a/public/Get-KbProxy.ps1
+++ b/public/Get-KbProxy.ps1
@@ -1,0 +1,32 @@
+function Get-KbProxy {
+    <#
+    .SYNOPSIS
+        Gets the proxy configuration used by kbupdate.
+
+    .DESCRIPTION
+        Shows whether kbupdate uses a custom proxy or automatic system-proxy detection and whether an alternate proxy credential is configured for the current PowerShell session. The credential itself is never returned.
+
+    .EXAMPLE
+        PS C:\> Get-KbProxy
+
+        Shows the active kbupdate proxy configuration without exposing the credential.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $proxy = Get-PSFConfigValue -FullName kbupdate.app.proxy
+    $proxyCredential = Get-PSFConfigValue -FullName kbupdate.app.proxycredential
+
+    if ($proxy) {
+        $mode = 'Custom'
+    } else {
+        $mode = 'Automatic'
+    }
+
+    [pscustomobject]@{
+        Mode                     = $mode
+        Proxy                    = $proxy
+        CredentialConfigured     = [bool]$proxyCredential
+        CredentialUserName       = if ($proxyCredential) { $proxyCredential.UserName } else { $null }
+    }
+}

--- a/public/Get-KbUpdate.ps1
+++ b/public/Get-KbUpdate.ps1
@@ -70,6 +70,12 @@ function Get-KbUpdate {
 
         Unless you set -Source Web, more than 25xMaxPages may be returned (because db lookups are faster and dont need to care about paging).
 
+    .PARAMETER Proxy
+        Proxy server URI used for Microsoft Update Catalog web requests. When omitted, the system proxy configuration is detected automatically.
+
+    .PARAMETER ProxyCredential
+        Alternate credential used to authenticate to Proxy. When Proxy is omitted, the command uses the automatically detected system proxy. The credential is used only for the current command unless configured with Set-KbProxy.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -129,6 +135,11 @@ function Get-KbUpdate {
         PS C:\> Get-KbUpdate -Pattern "Windows Server 2019" -MaxPages 2 -Source Web
 
         Gets KBs for Windows Server 2019 from the web, and returns 2 pages (up to 50 results) instead of 1 (25 max).
+
+    .EXAMPLE
+        PS C:\> Get-KbUpdate -Pattern KB5062557 -Source Web -Proxy http://proxy.contoso.com:8080 -ProxyCredential (Get-Credential)
+
+        Searches the catalog through a custom authenticated proxy. Omit Proxy to use the system proxy automatically.
 #>
     [CmdletBinding()]
     param(
@@ -152,9 +163,19 @@ function Get-KbUpdate {
         [int]$MaxPages = 1,
         [datetime]$Since,
         [string]$CustomQuery,
+        [uri]$Proxy = (Get-PSFConfigValue -FullName kbupdate.app.proxy),
+        [pscredential]$ProxyCredential = (Get-PSFConfigValue -FullName kbupdate.app.proxycredential),
         [switch]$EnableException
     )
     begin {
+        $webRequestParameters = @{}
+        if ($Proxy) {
+            $webRequestParameters.Proxy = $Proxy
+        }
+        if ($ProxyCredential) {
+            $webRequestParameters.ProxyCredential = $ProxyCredential
+        }
+
         $script:MaxPages = $MaxPages
         if ($NoMultithreading) {
             Write-PSFMessage -Level Warning -Message "Multithreading now disabled by default. This parameter will likely be removed in future versions."
@@ -460,7 +481,7 @@ function Get-KbUpdate {
                     $os = $OperatingSystem -join '" "'
                     $url = "https://www.catalog.update.microsoft.com/Search.aspx?q=$kb+`"$os`""
                     Write-PSFMessage -Level Verbose -Message "Accessing $url"
-                    $results = Invoke-TlsWebRequest -Uri $url
+                    $results = Invoke-TlsWebRequest @webRequestParameters -Uri $url
                     $kbids = $results.InputFields |
                         Where-Object { $_.type -eq 'Button' -and ($_.Value -eq 'Download' -or $_.class -eq 'flatBlueButtonDownload focus-only') } |
                         Select-Object -ExpandProperty ID
@@ -469,7 +490,7 @@ function Get-KbUpdate {
                     $url = "https://www.catalog.update.microsoft.com/Search.aspx?q=$kb"
                     $boundparams.OperatingSystem = $OperatingSystem
                     Write-PSFMessage -Level Verbose -Message "Failing back to $url"
-                    $results = Invoke-TlsWebRequest -Uri $url
+                    $results = Invoke-TlsWebRequest @webRequestParameters -Uri $url
                     $kbids = $results.InputFields |
                         Where-Object { $_.type -eq 'Button' -and ($_.Value -eq 'Download' -or $_.class -eq 'flatBlueButtonDownload focus-only') } |
                         Select-Object -ExpandProperty ID
@@ -478,7 +499,7 @@ function Get-KbUpdate {
 
                 if (-not $kbids) {
                     try {
-                        $null = Invoke-TlsWebRequest -Uri "https://support.microsoft.com/en-us/topic/$kb"
+                        $null = Invoke-TlsWebRequest @webRequestParameters -Uri "https://support.microsoft.com/en-us/topic/$kb"
                         Stop-PSFFunction -EnableException:$EnableException -Message "Matches were found for $kb, but the results no longer exist in the catalog"
                         return
                     } catch {
@@ -595,7 +616,7 @@ function Get-KbUpdate {
                     Write-ProgressHelper -TotalSteps $total -StepNumber $completed -Activity "Searching catalog" -Message "Downloading information for $itemtitle"
                     $post = @{ size = 0; updateID = $guid; uidInfo = $guid } | ConvertTo-Json -Compress
                     $body = @{ updateIDs = "[$post]" }
-                    Invoke-TlsWebRequest -Uri 'https://www.catalog.update.microsoft.com/DownloadDialog.aspx' -Method Post -Body $body | Select-Object -ExpandProperty Content
+                    Invoke-TlsWebRequest @webRequestParameters -Uri 'https://www.catalog.update.microsoft.com/DownloadDialog.aspx' -Method Post -Body $body | Select-Object -ExpandProperty Content
                 }
 
 
@@ -658,7 +679,7 @@ function Get-KbUpdate {
 
                     if (-not $Simple) {
                         # Multi-byte character is corrupted if passing BasicHtmlWebResponseObject to Get-Info -Text.
-                        $detaildialog = Invoke-TlsWebRequest -Uri "https://www.catalog.update.microsoft.com/ScopedViewInline.aspx?updateid=$updateid" | Select-Object -ExpandProperty Content
+                        $detaildialog = Invoke-TlsWebRequest @webRequestParameters -Uri "https://www.catalog.update.microsoft.com/ScopedViewInline.aspx?updateid=$updateid" | Select-Object -ExpandProperty Content
                         $description = Get-Info -Text $detaildialog -Pattern '<span id="ScopedViewHandler_desc">'
                         $lastmodified = Get-Info -Text $detaildialog -Pattern '<span id="ScopedViewHandler_date">'
                         $size = Get-Info -Text $detaildialog -Pattern '<span id="ScopedViewHandler_size">'

--- a/public/Save-KbUpdate.ps1
+++ b/public/Save-KbUpdate.ps1
@@ -49,6 +49,12 @@ function Save-KbUpdate {
     .PARAMETER Link
         When link is specified only the links in the array are processed and downloaded to the system.
 
+    .PARAMETER Proxy
+        Proxy server URI used for Microsoft Update Catalog lookups and update downloads. When omitted, the system proxy configuration is detected automatically.
+
+    .PARAMETER ProxyCredential
+        Alternate credential used to authenticate to Proxy. When Proxy is omitted, the command uses the automatically detected system proxy. The credential is used only for the current command unless configured with Set-KbProxy.
+
     .NOTES
         Tags: Update
         Author: Chrissy LeMaire (@cl), netnerds.net
@@ -89,6 +95,11 @@ function Save-KbUpdate {
         PS C:\> Import-Clixml E:\needed-updates.clixml | Save-KbUpdate -Path E:\updates
 
         Downloads the exact update links exported by Get-KbNeededUpdate on an offline computer.
+
+    .EXAMPLE
+        PS C:\> Save-KbUpdate -Pattern KB5062557 -Proxy http://proxy.contoso.com:8080 -ProxyCredential (Get-Credential)
+
+        Finds and downloads KB5062557 through a custom authenticated proxy. Omit Proxy to use the system proxy automatically.
     #>
     [CmdletBinding(DefaultParameterSetName = 'default', SupportsShouldProcess, ConfirmImpact = 'Low')]
     param(
@@ -109,9 +120,19 @@ function Save-KbUpdate {
         [switch]$AllowClobber,
         [ValidateSet("Wsus", "Web", "Database")]
         [string[]]$Source = (Get-PSFConfigValue -FullName kbupdate.app.source),
+        [uri]$Proxy = (Get-PSFConfigValue -FullName kbupdate.app.proxy),
+        [pscredential]$ProxyCredential = (Get-PSFConfigValue -FullName kbupdate.app.proxycredential),
         [switch]$EnableException
     )
     begin {
+        $webRequestParameters = @{}
+        if ($Proxy) {
+            $webRequestParameters.Proxy = $Proxy
+        }
+        if ($ProxyCredential) {
+            $webRequestParameters.ProxyCredential = $ProxyCredential
+        }
+
         $jobs = $inputobjects = $uniquelinks = @()
         $requestedPatterns = @(
             $Pattern |
@@ -182,12 +203,28 @@ function Save-KbUpdate {
                         try {
                             if ((Get-BitsTransfer | Where-Object Description -match kbupdate).FileList.RemoteName -notcontains $hyperlinklol) {
                                 Write-PSFMessage -Level Verbose -Message "Adding $filename to download queue"
-                                $jobs += Start-BitsTransfer -Asynchronous -Source $hyperlinklol -Destination $file -ErrorAction Stop -Description kbupdate
+                                $bitsParameters = @{
+                                    Asynchronous = $true
+                                    Source       = $hyperlinklol
+                                    Destination  = $file
+                                    ErrorAction  = 'Stop'
+                                    Description  = 'kbupdate'
+                                }
+                                if ($Proxy) {
+                                    $bitsParameters.ProxyUsage = 'Override'
+                                    $bitsParameters.ProxyList = $Proxy
+                                } elseif ($ProxyCredential) {
+                                    $bitsParameters.ProxyUsage = 'SystemDefault'
+                                }
+                                if ($ProxyCredential) {
+                                    $bitsParameters.ProxyCredential = $ProxyCredential
+                                }
+                                $jobs += Start-BitsTransfer @bitsParameters
                             }
                         } catch {
                             Write-PSFMessage -Level Verbose -Message "Going to use uri: $hyperlinklol"
                             Write-Progress -Activity "Downloading $file" -Id 1
-                            Invoke-TlsWebRequest -OutFile $file -Uri $hyperlinklol
+                            Invoke-TlsWebRequest @webRequestParameters -OutFile $file -Uri $hyperlinklol
                             Write-Progress -Activity "Downloading $file" -Id 1 -Completed
                             Get-ChildItem -Path $file -ErrorAction Ignore
                         }
@@ -196,7 +233,7 @@ function Save-KbUpdate {
                             Write-PSFMessage -Level Verbose -Message "Transfer failed. Trying again."
                             # IWR is crazy slow for large downloads
                             Write-Progress -Activity "Downloading $file" -Id 1
-                            Invoke-TlsWebRequest -OutFile $file -Uri $hyperlinklol
+                            Invoke-TlsWebRequest @webRequestParameters -OutFile $file -Uri $hyperlinklol
                             Write-Progress -Activity "Downloading $file" -Id 1 -Completed
                             Get-ChildItem -Path $file -ErrorAction Ignore
                         } catch {
@@ -244,6 +281,12 @@ function Save-KbUpdate {
 
                     if ($PSBoundParameters.Source) {
                         $params.Source = $Source
+                    }
+                    if ($Proxy) {
+                        $params.Proxy = $Proxy
+                    }
+                    if ($ProxyCredential) {
+                        $params.ProxyCredential = $ProxyCredential
                     }
 
                     $inputobjects += Get-KbUpdate @params
@@ -337,13 +380,29 @@ function Save-KbUpdate {
                                 $filename = Split-Path $hyperlinklol -Leaf
                                 if ((Get-BitsTransfer | Where-Object Description -match kbupdate).FileList.RemoteName -notcontains $hyperlinklol) {
                                     Write-PSFMessage -Level Verbose -Message "Adding $filename to download queue"
-                                    $jobs += Start-BitsTransfer -Asynchronous -Source $hyperlinklol -Destination $file -ErrorAction Stop -Description "kbupdate - $title"
+                                    $bitsParameters = @{
+                                        Asynchronous = $true
+                                        Source       = $hyperlinklol
+                                        Destination  = $file
+                                        ErrorAction  = 'Stop'
+                                        Description  = "kbupdate - $title"
+                                    }
+                                    if ($Proxy) {
+                                        $bitsParameters.ProxyUsage = 'Override'
+                                        $bitsParameters.ProxyList = $Proxy
+                                    } elseif ($ProxyCredential) {
+                                        $bitsParameters.ProxyUsage = 'SystemDefault'
+                                    }
+                                    if ($ProxyCredential) {
+                                        $bitsParameters.ProxyCredential = $ProxyCredential
+                                    }
+                                    $jobs += Start-BitsTransfer @bitsParameters
                                 }
                             } catch {
                                 foreach ($hyperlink in $hyperlinklol) {
                                     Write-Progress -Activity "Downloading $downloadFileName" -Id 1
                                     Write-PSFMessage -Level Verbose -Message "That failed, trying Invoke-WebRequest"
-                                    $null = Invoke-TlsWebRequest -OutFile $file -Uri "$hyperlink"
+                                    $null = Invoke-TlsWebRequest @webRequestParameters -OutFile $file -Uri "$hyperlink"
                                     Write-Progress -Activity "Downloading $downloadFileName" -Id 1 -Completed
                                     Get-ChildItem -Path $file -ErrorAction Ignore
                                 }
@@ -352,7 +411,7 @@ function Save-KbUpdate {
                             try {
                                 # IWR is crazy slow for large downloads
                                 Write-Progress -Activity "Downloading $downloadFileName" -Id 1
-                                $null = Invoke-TlsWebRequest -OutFile $file -Uri "$hyperlinklol"
+                                $null = Invoke-TlsWebRequest @webRequestParameters -OutFile $file -Uri "$hyperlinklol"
                                 Write-Progress -Activity "Downloading $downloadFileName" -Id 1 -Completed
                             } catch {
                                 Stop-PSFFunction -EnableException:$EnableException -Message "Failure" -ErrorRecord $PSItem -Continue

--- a/public/Set-KbProxy.ps1
+++ b/public/Set-KbProxy.ps1
@@ -1,0 +1,60 @@
+function Set-KbProxy {
+    <#
+    .SYNOPSIS
+        Configures proxy behavior for kbupdate web requests.
+
+    .DESCRIPTION
+        Configures a custom proxy or automatic system-proxy detection for Get-KbUpdate and Save-KbUpdate. An alternate proxy credential can be kept in memory for the current PowerShell session. This command does not write the credential to disk.
+
+        Per-command Proxy and ProxyCredential parameters override these settings for one call.
+
+    .PARAMETER Proxy
+        Custom proxy server URI used for catalog lookups and downloads.
+
+    .PARAMETER AutoDetect
+        Uses the operating system proxy configuration automatically. Supply ProxyCredential when the detected proxy requires a different account.
+
+    .PARAMETER ProxyCredential
+        Alternate credential used to authenticate to the custom or automatically detected proxy. The credential remains in memory only for the current PowerShell session.
+
+    .EXAMPLE
+        PS C:\> Set-KbProxy -Proxy http://proxy.contoso.com:8080 -ProxyCredential (Get-Credential)
+
+        Uses a custom proxy and alternate credential for later kbupdate commands in this PowerShell session.
+
+    .EXAMPLE
+        PS C:\> Set-KbProxy -AutoDetect -ProxyCredential (Get-Credential)
+
+        Detects the system proxy automatically and uses an alternate credential for it.
+
+    .EXAMPLE
+        PS C:\> Set-KbProxy -AutoDetect
+
+        Returns to automatic system-proxy detection with the current user's default credentials.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Manual', SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'Manual')]
+        [uri]$Proxy,
+        [Parameter(Mandatory, ParameterSetName = 'Automatic')]
+        [switch]$AutoDetect,
+        [Parameter(ParameterSetName = 'Manual')]
+        [Parameter(ParameterSetName = 'Automatic')]
+        [pscredential]$ProxyCredential
+    )
+
+    if (-not $PSCmdlet.ShouldProcess('kbupdate proxy configuration', "Use $($PSCmdlet.ParameterSetName.ToLowerInvariant()) proxy settings")) {
+        return
+    }
+
+    if ($PSCmdlet.ParameterSetName -eq 'Manual') {
+        $configuredProxy = $Proxy
+    } else {
+        $configuredProxy = $null
+    }
+
+    $null = Set-PSFConfig -FullName kbupdate.app.proxy -Value $configuredProxy
+    $null = Set-PSFConfig -FullName kbupdate.app.proxycredential -Value $ProxyCredential
+
+    Get-KbProxy
+}

--- a/tests/unit/Get-KbUpdateProxy.Tests.ps1
+++ b/tests/unit/Get-KbUpdateProxy.Tests.ps1
@@ -1,0 +1,33 @@
+BeforeAll {
+    $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    Import-Module (Join-Path $repositoryRoot 'kbupdate.psd1') -Force -ErrorAction Stop
+}
+
+Describe 'Get-KbUpdate authenticated proxy handling' {
+    InModuleScope kbupdate {
+        It 'forwards a custom proxy and alternate credential to catalog requests' {
+            $guid = '55555555-5555-5555-5555-555555555555'
+            $content = @"
+enTitle = 'Authenticated proxy update';
+longLanguages = 'all';
+updateID = '$guid';
+isHotFix = false;
+url = 'https://catalog.s.download.windowsupdate.com/test/proxy-catalog.msu';
+"@
+            Mock Invoke-TlsWebRequest {
+                [pscustomobject]@{ Content = $content }
+            }
+
+            $credential = New-Object pscredential 'proxy-user', (ConvertTo-SecureString 'proxy-password' -AsPlainText -Force)
+            $proxy = [uri]'http://proxy.contoso.com:8080'
+
+            $result = @(Get-KbUpdate -Pattern $guid -Source Web -Simple -Proxy $proxy -ProxyCredential $credential -EnableException)
+
+            $result.Count | Should -Be 1
+            $result[0].Link | Should -Be 'https://catalog.s.download.windowsupdate.com/test/proxy-catalog.msu'
+            Should -Invoke Invoke-TlsWebRequest -Times 1 -Exactly -ParameterFilter {
+                $Proxy -eq $proxy -and $ProxyCredential.UserName -eq 'proxy-user'
+            }
+        }
+    }
+}

--- a/tests/unit/Invoke-TlsWebRequest.Tests.ps1
+++ b/tests/unit/Invoke-TlsWebRequest.Tests.ps1
@@ -1,0 +1,78 @@
+BeforeAll {
+    $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    Import-Module (Join-Path $repositoryRoot 'kbupdate.psd1') -Force -ErrorAction Stop
+}
+
+Describe 'Invoke-TlsWebRequest proxy handling' {
+    InModuleScope kbupdate {
+        BeforeEach {
+            $script:MaxPages = 1
+            $script:websession = $null
+            $script:previouspage = $null
+            Mock Get-ItemProperty { [pscustomobject]@{ ProxyServer = $null; ProxyEnable = 0 } }
+            Mock Invoke-WebRequest { [pscustomobject]@{ Content = 'ok' } }
+        }
+
+        It 'passes a custom proxy and alternate credential to Invoke-WebRequest' {
+            $credential = New-Object pscredential 'proxy-user', (ConvertTo-SecureString 'proxy-password' -AsPlainText -Force)
+            $proxy = [uri]'http://proxy.contoso.com:8080'
+
+            $result = Invoke-TlsWebRequest -Uri 'https://www.catalog.update.microsoft.com/' -Proxy $proxy -ProxyCredential $credential
+
+            $result.Content | Should -Be 'ok'
+            Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
+                $Proxy -eq $proxy -and $ProxyCredential.UserName -eq 'proxy-user'
+            }
+        }
+
+        It 'uses default credentials with a custom proxy when none are supplied' {
+            $proxy = [uri]'http://proxy.contoso.com:8080'
+
+            $null = Invoke-TlsWebRequest -Uri 'https://www.catalog.update.microsoft.com/' -Proxy $proxy
+
+            Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
+                $Proxy -eq $proxy -and $ProxyUseDefaultCredentials
+            }
+        }
+
+        It 'detects the system proxy when only an alternate credential is supplied' {
+            $originalProxy = [Net.WebRequest]::DefaultWebProxy
+            $proxy = [uri]'http://system-proxy.contoso.com:8080'
+            $credential = New-Object pscredential 'proxy-user', (ConvertTo-SecureString 'proxy-password' -AsPlainText -Force)
+
+            try {
+                [Net.WebRequest]::DefaultWebProxy = New-Object Net.WebProxy $proxy
+                $null = Invoke-TlsWebRequest -Uri 'https://www.catalog.update.microsoft.com/' -ProxyCredential $credential
+            } finally {
+                [Net.WebRequest]::DefaultWebProxy = $originalProxy
+            }
+
+            Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
+                $Proxy -eq $proxy -and $ProxyCredential.UserName -eq 'proxy-user'
+            }
+        }
+
+        It 'keeps multi-page catalog requests working after proxy parameter binding' {
+            $script:MaxPages = 2
+            Mock Invoke-WebRequest {
+                [pscustomobject]@{
+                    Content = 'ok'
+                    InputFields = @(
+                        [pscustomobject]@{ Name = '__VIEWSTATE'; Value = 'state' }
+                        [pscustomobject]@{ Name = '__EVENTARGUMENT'; Value = 'argument' }
+                        [pscustomobject]@{ Name = '__VIEWSTATEGENERATOR'; Value = 'generator' }
+                        [pscustomobject]@{ Name = '__EVENTVALIDATION'; Value = 'validation' }
+                    )
+                }
+            }
+
+            $result = @(Invoke-TlsWebRequest -Uri 'https://www.catalog.update.microsoft.com/Search.aspx?q=test')
+
+            $result.Count | Should -Be 2
+            Should -Invoke Invoke-WebRequest -Times 2 -Exactly
+            Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'POST' -and $Body['__VIEWSTATE'] -eq 'state'
+            }
+        }
+    }
+}

--- a/tests/unit/KbProxyConfiguration.Tests.ps1
+++ b/tests/unit/KbProxyConfiguration.Tests.ps1
@@ -1,0 +1,70 @@
+BeforeAll {
+    $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    Import-Module (Join-Path $repositoryRoot 'kbupdate.psd1') -Force -ErrorAction Stop
+}
+
+Describe 'kbupdate proxy configuration' {
+    InModuleScope kbupdate {
+        It 'reports configuration without returning the credential object' {
+            $credential = New-Object pscredential 'proxy-user', (ConvertTo-SecureString 'proxy-password' -AsPlainText -Force)
+            Mock Get-PSFConfigValue {
+                if ($FullName -eq 'kbupdate.app.proxy') {
+                    return [uri]'http://proxy.contoso.com:8080'
+                }
+                if ($FullName -eq 'kbupdate.app.proxycredential') {
+                    return $credential
+                }
+            }
+
+            $result = Get-KbProxy
+
+            $result.Mode | Should -Be 'Custom'
+            $result.Proxy.AbsoluteUri | Should -Be 'http://proxy.contoso.com:8080/'
+            $result.CredentialConfigured | Should -BeTrue
+            $result.CredentialUserName | Should -Be 'proxy-user'
+            $result.PSObject.Properties.Name | Should -Not -Contain 'ProxyCredential'
+        }
+
+        It 'stores a custom proxy and credential for the current session' {
+            Mock Set-PSFConfig
+            Mock Get-KbProxy { [pscustomobject]@{ Mode = 'Custom' } }
+            $credential = New-Object pscredential 'proxy-user', (ConvertTo-SecureString 'proxy-password' -AsPlainText -Force)
+            $proxy = [uri]'http://proxy.contoso.com:8080'
+
+            $result = Set-KbProxy -Proxy $proxy -ProxyCredential $credential -Confirm:$false
+
+            $result.Mode | Should -Be 'Custom'
+            Should -Invoke Set-PSFConfig -Times 1 -Exactly -ParameterFilter {
+                $FullName -eq 'kbupdate.app.proxy' -and $Value -eq $proxy
+            }
+            Should -Invoke Set-PSFConfig -Times 1 -Exactly -ParameterFilter {
+                $FullName -eq 'kbupdate.app.proxycredential' -and $Value.UserName -eq 'proxy-user'
+            }
+        }
+
+        It 'returns to automatic detection and clears the alternate credential' {
+            Mock Set-PSFConfig
+            Mock Get-KbProxy { [pscustomobject]@{ Mode = 'Automatic' } }
+
+            $result = Set-KbProxy -AutoDetect -Confirm:$false
+
+            $result.Mode | Should -Be 'Automatic'
+            Should -Invoke Set-PSFConfig -Times 1 -Exactly -ParameterFilter {
+                $FullName -eq 'kbupdate.app.proxy' -and $null -eq $Value
+            }
+            Should -Invoke Set-PSFConfig -Times 1 -Exactly -ParameterFilter {
+                $FullName -eq 'kbupdate.app.proxycredential' -and $null -eq $Value
+            }
+        }
+
+        It 'does not change configuration under WhatIf' {
+            Mock Set-PSFConfig
+            Mock Get-KbProxy
+
+            $null = Set-KbProxy -AutoDetect -WhatIf
+
+            Should -Invoke Set-PSFConfig -Times 0 -Exactly
+            Should -Invoke Get-KbProxy -Times 0 -Exactly
+        }
+    }
+}

--- a/tests/unit/Save-KbUpdate.Tests.ps1
+++ b/tests/unit/Save-KbUpdate.Tests.ps1
@@ -134,5 +134,58 @@ Describe 'Save-KbUpdate download handling' {
             }
             Should -Invoke Invoke-TlsWebRequest -Times 1 -Exactly
         }
+
+        It 'forwards a custom proxy and alternate credential to lookup and download' {
+            Mock Get-Command { $null }
+            Mock Get-KbUpdate {
+                [pscustomobject]@{
+                    Title    = 'Authenticated proxy update'
+                    UpdateId = '44444444-4444-4444-4444-444444444444'
+                    Link     = 'https://catalog.s.download.windowsupdate.com/test/proxy.msu'
+                }
+            }
+            Mock Invoke-TlsWebRequest
+
+            $credential = New-Object pscredential 'proxy-user', (ConvertTo-SecureString 'proxy-password' -AsPlainText -Force)
+            $proxy = [uri]'http://proxy.contoso.com:8080'
+
+            $null = Save-KbUpdate -Pattern KB5000004 -Path $TestDrive -Proxy $proxy -ProxyCredential $credential -Confirm:$false
+
+            Should -Invoke Get-KbUpdate -Times 1 -Exactly -ParameterFilter {
+                $Proxy -eq $proxy -and $ProxyCredential.UserName -eq 'proxy-user'
+            }
+            Should -Invoke Invoke-TlsWebRequest -Times 1 -Exactly -ParameterFilter {
+                $Proxy -eq $proxy -and $ProxyCredential.UserName -eq 'proxy-user'
+            }
+        }
+
+        It 'forwards custom authenticated proxy settings to BITS' -Skip:($env:OS -ne 'Windows_NT') {
+            Mock Start-BitsTransfer
+
+            $credential = New-Object pscredential 'proxy-user', (ConvertTo-SecureString 'proxy-password' -AsPlainText -Force)
+            $proxy = [uri]'http://proxy.contoso.com:8080'
+
+            $null = Save-KbUpdate -Link 'https://catalog.s.download.windowsupdate.com/test/proxy-bits.msu' -Path 'C:\Temp\kbupdate-tests' -Proxy $proxy -ProxyCredential $credential -Confirm:$false
+
+            Should -Invoke Start-BitsTransfer -Times 1 -Exactly -ParameterFilter {
+                $ProxyUsage -eq 'Override' -and
+                    $ProxyList -eq $proxy -and
+                    $ProxyCredential.UserName -eq 'proxy-user'
+            }
+        }
+
+        It 'uses preconfigured BITS proxy detection with an alternate credential' -Skip:($env:OS -ne 'Windows_NT') {
+            Mock Start-BitsTransfer
+
+            $credential = New-Object pscredential 'proxy-user', (ConvertTo-SecureString 'proxy-password' -AsPlainText -Force)
+
+            $null = Save-KbUpdate -Link 'https://catalog.s.download.windowsupdate.com/test/auto-proxy-bits.msu' -Path 'C:\Temp\kbupdate-tests' -ProxyCredential $credential -Confirm:$false
+
+            Should -Invoke Start-BitsTransfer -Times 1 -Exactly -ParameterFilter {
+                $ProxyUsage -eq 'SystemDefault' -and
+                    -not $ProxyList -and
+                    $ProxyCredential.UserName -eq 'proxy-user'
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add `-Proxy` and `-ProxyCredential` overrides to `Get-KbUpdate` and `Save-KbUpdate`
- keep system-proxy detection as the default, including alternate credentials for an automatically detected proxy
- add `Get-KbProxy` and `Set-KbProxy` for reusable, session-scoped proxy settings
- forward proxy settings through both `Invoke-WebRequest` and BITS download paths
- never return the credential object or write it to disk

## Root cause

The web helper only applied the logged-in user's default network credentials to a registry-discovered proxy. Callers could not provide a different proxy account, and the catalog lookup and download paths had no shared configurable proxy contract.

## Usage

```powershell
Set-KbProxy -Proxy http://proxy.contoso.com:8080 -ProxyCredential (Get-Credential)
Save-KbUpdate -Name KB5062557

# Or use the system proxy with another account
Set-KbProxy -AutoDetect -ProxyCredential (Get-Credential)
```

Per-command `-Proxy` and `-ProxyCredential` values override the session settings.

## Validation

- `./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap` — 52 passed
- `./build/Invoke-KbUpdateIntegration.ps1` — 6 passed, 3 mutation/download tests skipped
- live read-only parsing verified for both `download.windowsupdate.com` and `delivery.mp.microsoft.com` links
- Windows PowerShell import/export smoke test passed
- real PSFramework session configuration set/reset smoke test passed

Closes #242