### PR TITLE
Guard DSC module loading order

### DIFF
--- a/tests/unit/ModuleSafety.Tests.ps1
+++ b/tests/unit/ModuleSafety.Tests.ps1
@@ -43,5 +43,19 @@ Describe 'AI-safe command metadata' {
 
         $dscWorker | Should -Not -Match 'Get-PSSession\s+-ComputerName'
     }
+
+    It 'loads xWindowsUpdate on the target before compiling the DSC fallback' {
+        $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+        $dscWorker = Get-Content -LiteralPath (Join-Path $repositoryRoot 'private/Start-DscUpdate.ps1') -Raw
+        $remoteBlockStart = $dscWorker.IndexOf('$null = Invoke-KbCommand @parms -ScriptBlock {')
+        $moduleImport = $dscWorker.IndexOf('Import-Module xWindowsUpdate -RequiredVersion 3.0.0', $remoteBlockStart)
+        $fallbackCompilation = $dscWorker.IndexOf('$dsc = [scriptblock]::Create($DscScript)', $remoteBlockStart)
+
+        $remoteBlockStart | Should -BeGreaterThan -1
+        $moduleImport | Should -BeGreaterThan $remoteBlockStart
+        $fallbackCompilation | Should -BeGreaterThan $moduleImport
+        $dscWorker.Substring(0, $remoteBlockStart) |
+            Should -Not -Match '\[scriptblock\]::Create\(\$scriptblock\)'
+    }
 }
 


### PR DESCRIPTION
## Summary

- add a deterministic regression assertion for the `xWindowsUpdate` load/compile order
- verify DSC fallback compilation occurs inside the target-side command block
- verify `xWindowsUpdate` 3.0.0 is imported before the fallback configuration is compiled
- verify the controller no longer compiles the old `$scriptblock` before target setup

## Why this closes the issue

The reported failure came from the former controller-side `[scriptblock]::Create($scriptblock)` calls. The controller could not discover the vendored prerelease `xWindowsUpdate` module because it had only been copied to the target. PR #245 moved fallback compilation into the target-side block after `Import-Module xWindowsUpdate -RequiredVersion 3.0.0`, which resolves that ordering bug. This PR locks the corrected behavior with a focused regression test.

No module installation, update installation, or VM mutation was used for verification.

## Validation

- focused `ModuleSafety.Tests.ps1` run — 5 passed
- `./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap` — 53 passed
- both `Install-KbUpdate -WhatIf` safety paths passed

Closes #232