### PR TITLE
Degrade gracefully when native SQLite is unavailable (ARM64)

### DIFF
--- a/private/Test-KbSqliteSupport.ps1
+++ b/private/Test-KbSqliteSupport.ps1
@@ -1,0 +1,39 @@
+function Test-KbSqliteSupport {
+    <#
+    .SYNOPSIS
+        Determines whether the bundled native SQLite provider can be loaded on the current system.
+
+    .DESCRIPTION
+        kbupdate reads its local update database through PSSQLite, which loads a native
+        SQLite.Interop.dll matching the running process architecture. PSSQLite ships native
+        libraries for win-x64, win-x86, linux-x64, and osx-x64 but not for ARM64, so on a
+        native ARM64 PowerShell process the provider fails to load with
+        "An attempt was made to load a program with an incorrect format" (HRESULT 0x8007000B).
+
+        This helper probes the provider once with a trivial query and caches the result in
+        $script:sqlitesupport so callers can degrade gracefully instead of surfacing the raw
+        provider error. It performs no writes and is safe to call repeatedly.
+
+    .EXAMPLE
+        PS C:\> Test-KbSqliteSupport
+
+        Returns $true when the local database can be queried, otherwise $false.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    if ($null -ne $script:sqlitesupport) {
+        return $script:sqlitesupport
+    }
+
+    try {
+        $null = Invoke-SqliteQuery -DataSource $script:basedb -Query "SELECT 1 AS Probe" -ErrorAction Stop
+        $script:sqlitesupport = $true
+    } catch {
+        Write-PSFMessage -Level Verbose -Message "Native SQLite provider is unavailable on this system: $($PSItem.Exception.Message)"
+        $script:sqlitesupport = $false
+    }
+
+    $script:sqlitesupport
+}

--- a/public/Get-KbUpdate.ps1
+++ b/public/Get-KbUpdate.ps1
@@ -434,11 +434,15 @@ function Get-KbUpdate {
                         } catch {
                             #whatever
                         }
-                    } else {
+                    } elseif (Test-KbSqliteSupport) {
                         # I do wish my import didn't return empties but sometimes it does so check for length of 3
-                        $supersededby = Invoke-SqliteQuery -DataSource $script:basedb -Query "select KB, Description from SupersededBy where UpdateId = '$($guid)' COLLATE NOCASE and LENGTH(kb) > 3"
-                        $supersedes = Invoke-SqliteQuery -DataSource $script:basedb -Query "select KB, Description from Supersedes where UpdateId = '$($guid)' COLLATE NOCASE and LENGTH(kb) > 3"
-                        $link = (Invoke-SqliteQuery -DataSource $script:basedb -Query "select DISTINCT Link from Link where UpdateId = '$($guid)' COLLATE NOCASE").Link
+                        try {
+                            $supersededby = Invoke-SqliteQuery -DataSource $script:basedb -Query "select KB, Description from SupersededBy where UpdateId = '$($guid)' COLLATE NOCASE and LENGTH(kb) > 3"
+                            $supersedes = Invoke-SqliteQuery -DataSource $script:basedb -Query "select KB, Description from Supersedes where UpdateId = '$($guid)' COLLATE NOCASE and LENGTH(kb) > 3"
+                            $link = (Invoke-SqliteQuery -DataSource $script:basedb -Query "select DISTINCT Link from Link where UpdateId = '$($guid)' COLLATE NOCASE").Link
+                        } catch {
+                            Write-PSFMessage -Level Verbose -Message "Could not enrich $guid from the local database: $($PSItem.Exception.Message)"
+                        }
                     }
                 }
 
@@ -863,6 +867,20 @@ function Get-KbUpdate {
             Write-PSFMessage -Level Verbose -Message "Source is ignored when Latest is specified, as latest requires the freshest data from the web. Use -Force to override this."
             $PSBoundParameters.Source = $null
             $Source = "Web"
+        }
+
+        if (($Source -contains "Database") -and -not (Test-KbSqliteSupport)) {
+            $architecturename = "$env:PROCESSOR_ARCHITECTURE"
+            if (-not $architecturename) {
+                $architecturename = "this"
+            }
+            if (($Source | Where-Object { $PSItem -ne "Database" })) {
+                Write-PSFMessage -Level Warning -Message "Skipping the local update database: the bundled SQLite provider (PSSQLite) has no native library for the $architecturename processor architecture. Continuing with the remaining sources. To use the database, run kbupdate from the x64 or x86 Windows PowerShell, where the bundled SQLite loads under emulation."
+                $Source = @($Source | Where-Object { $PSItem -ne "Database" })
+            } else {
+                Stop-PSFFunction -Message "kbupdate cannot query its local update database on this system. The bundled SQLite provider (PSSQLite) does not include a native library for the $architecturename processor architecture, so the Database source is unavailable. Use '-Source Web' instead, or run kbupdate from the x64 or x86 Windows PowerShell, where the bundled SQLite loads under emulation." -EnableException:$EnableException
+                return
+            }
         }
 
         foreach ($computer in $Computername) {

--- a/tests/unit/Test-KbSqliteSupport.Tests.ps1
+++ b/tests/unit/Test-KbSqliteSupport.Tests.ps1
@@ -1,0 +1,95 @@
+BeforeAll {
+    $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    Import-Module (Join-Path $repositoryRoot 'kbupdate.psd1') -Force -ErrorAction Stop
+}
+
+Describe 'Test-KbSqliteSupport native provider probe' {
+    InModuleScope kbupdate {
+        BeforeEach {
+            $script:sqlitesupport = $null
+        }
+
+        It 'reports support when the native SQLite provider loads' {
+            Mock Invoke-SqliteQuery { [pscustomobject]@{ Probe = 1 } }
+
+            Test-KbSqliteSupport | Should -BeTrue
+        }
+
+        It 'reports no support when the native SQLite provider cannot be loaded' {
+            Mock Invoke-SqliteQuery {
+                throw 'An attempt was made to load a program with an incorrect format. (Exception from HRESULT: 0x8007000B)'
+            }
+
+            Test-KbSqliteSupport | Should -BeFalse
+        }
+
+        It 'probes only once and caches the result for the session' {
+            Mock Invoke-SqliteQuery { [pscustomobject]@{ Probe = 1 } }
+
+            $null = Test-KbSqliteSupport
+            $null = Test-KbSqliteSupport
+
+            Should -Invoke Invoke-SqliteQuery -Times 1 -Exactly
+        }
+    }
+}
+
+Describe 'Get-KbUpdate graceful degradation without native SQLite (issue #230)' {
+    InModuleScope kbupdate {
+        BeforeEach {
+            $script:sqlitesupport = $null
+            $global:kbupdate = $null
+            # Isolate from catalog results cached by other test files in the same session
+            $script:kbcollection = [hashtable]::Synchronized(@{ })
+        }
+
+        It 'gives actionable guidance instead of the raw provider error for a database-only query' {
+            Mock Invoke-SqliteQuery {
+                throw 'An attempt was made to load a program with an incorrect format. (Exception from HRESULT: 0x8007000B)'
+            }
+
+            { Get-KbUpdate -Pattern KB5033372 -Source Database -EnableException } |
+                Should -Throw '*x64 or x86 Windows PowerShell*'
+        }
+
+        It 'still returns web results when the local database is unavailable' {
+            $guid = 'a2300001-0230-0230-0230-000000000230'
+            $content = @"
+enTitle = 'ARM64 web fallback update';
+longLanguages = 'all';
+updateID = '$guid';
+isHotFix = false;
+url = 'https://catalog.s.download.windowsupdate.com/test/arm64-fallback.msu';
+"@
+            Mock Invoke-TlsWebRequest { [pscustomobject]@{ Content = $content } }
+            Mock Invoke-SqliteQuery {
+                throw 'An attempt was made to load a program with an incorrect format. (Exception from HRESULT: 0x8007000B)'
+            }
+
+            $result = @(Get-KbUpdate -Pattern $guid -Source Web -Simple -EnableException)
+
+            $result.Count | Should -Be 1
+            $result[0].Link | Should -Be 'https://catalog.s.download.windowsupdate.com/test/arm64-fallback.msu'
+        }
+
+        It 'drops the database source but continues with the web source when both are requested' {
+            $guid = 'a2300002-0230-0230-0230-000000000230'
+            $content = @"
+enTitle = 'ARM64 combined source update';
+longLanguages = 'all';
+updateID = '$guid';
+isHotFix = false;
+url = 'https://catalog.s.download.windowsupdate.com/test/arm64-combined.msu';
+"@
+            Mock Invoke-TlsWebRequest { [pscustomobject]@{ Content = $content } }
+            Mock Invoke-SqliteQuery {
+                throw 'An attempt was made to load a program with an incorrect format. (Exception from HRESULT: 0x8007000B)'
+            }
+
+            $result = @(Get-KbUpdate -Pattern $guid -Source Web, Database -Simple -EnableException)
+
+            $result.Count | Should -Be 1
+            $result[0].Link | Should -Be 'https://catalog.s.download.windowsupdate.com/test/arm64-combined.msu'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #230 — the module failed on ARM64 platforms with a cryptic three-error cascade.

kbupdate reads its local update database through **PSSQLite**, which loads a native `SQLite.Interop.dll` matching the running process architecture. PSSQLite ships native libraries for `win-x64`, `win-x86`, `linux-x64`, and `osx-x64` — **but none for ARM64**. On a native ARM64 PowerShell process the provider fails to load with:

> New-Object : Exception calling ".ctor" with "1" argument(s): "An attempt was made to load a program with an incorrect format. (Exception from HRESULT: 0x8007000B)"

…followed by two downstream errors, leaving ARM64 users with no idea what went wrong or how to proceed.

## Approach (bounded, no native binaries)

This does **not** vendor an ARM64 SQLite binary (out of scope, not CI-verifiable, and touches the vendored `library/` provenance rules). Instead it degrades gracefully:

- New private helper **`Test-KbSqliteSupport`** probes the native provider once (`SELECT 1`) and caches the result for the session.
- `Get-KbUpdate` now:
  - **Returns web results** when the local database can't be queried — the web-path SQLite enrichment (supersedes / superseded-by / links) becomes best-effort instead of fatal.
  - Emits **one actionable message** for a `-Source Database`-only request: use `-Source Web`, or run kbupdate under the x64/x86 Windows PowerShell (where the bundled SQLite loads under emulation).
  - **Drops `Database` and continues** with the remaining sources (e.g. the default `Web, Database`) when other sources are also requested, so `Get-KbUpdate KB…` just works on ARM64.

Systems with a working native provider are completely unaffected (the probe returns `$true` and behavior is identical to before).

## Tests

`tests/unit/Test-KbSqliteSupport.Tests.ps1` (deterministic, mocked):

- probe reports support / no-support and caches (single probe per session)
- database-only query yields the actionable guidance instead of the raw provider error
- web results still return when the local database is unavailable
- the database source is dropped but web continues when both are requested

## Verification

- `./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap` — all new tests pass; the only failures are the pre-existing `Start-BitsTransfer` tests that require the Windows-PowerShell BITS module (confirmed identical on clean `main` locally; green on the Windows CI runners).
- Live read-only catalog probes after the web-path change confirm both host families still parse:
  - legacy: KB5062557 → `catalog.s.download.windowsupdate.com`
  - delivery: KB5062553 / KB5063878 / KB5058411 → `catalog.sf.dl.delivery.mp.microsoft.com`
- Preserves Windows PowerShell 3.0 compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)