### PR TITLE
Parse catalog dates using the requested language's culture

### DIFF
--- a/private/Repair-Date.ps1
+++ b/private/Repair-Date.ps1
@@ -1,21 +1,77 @@
-function Repair-Date ($date) {
-    if ($date) {
-        $date = "$date".Replace(" ", "").Replace(".","/")
-        if ("$(Get-Culture)" -ne "en-US") {
-            try {
-                $datetime = [DateTime]::ParseExact("$date 12:00:00 AM", "M/d/yyyy h:mm:ss tt",[System.Globalization.DateTimeFormatInfo]::InvariantInfo, "None")
-                Get-Date $datetime -Format "yyyy-MM-dd" -ErrorAction Stop
-            } catch {
-                $null
-            }
+function Repair-Date {
+    <#
+        .SYNOPSIS
+            Normalizes an update's LastModified value to an invariant yyyy-MM-dd string.
+
+        .DESCRIPTION
+            The Microsoft Update Catalog localizes the displayed "Last Updated" date to the
+            Accept-Language header kbupdate sends for the -Language parameter. A US request
+            returns 7/8/2025 (M/d/yyyy) while a German request returns 08.07.2025 (dd.MM.yyyy)
+            and a French request returns 08/07/2025 (dd/MM/yyyy) for the very same update.
+
+            Parsing every value as US M/d/yyyy therefore silently swaps the month and day for
+            localized responses (or drops the date entirely when the day is greater than 12),
+            so this helper parses using the culture that matches the requested language. The
+            local database stores US-format dates, so the language-less default stays US.
+
+        .PARAMETER Date
+            The raw date value. A [datetime] is normalized directly; a string is parsed.
+
+        .PARAMETER Language
+            The -Language value used for the catalog request (a code such as "de" or "de-DE",
+            or a display name such as "German"). Determines the culture used to parse a string.
+    #>
+    [CmdletBinding()]
+    param(
+        $Date,
+        $Language
+    )
+
+    if (-not $Date) {
+        return $null
+    }
+
+    # A real DateTime needs no locale parsing
+    if ($Date -is [datetime]) {
+        return $Date.ToString("yyyy-MM-dd", [System.Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    $enus = [System.Globalization.CultureInfo]::GetCultureInfo("en-US")
+
+    # Resolve the culture that matches the Accept-Language kbupdate sent for this request
+    $culture = $enus
+    if ($Language) {
+        if ($Language -is [System.Globalization.CultureInfo]) {
+            $culture = $Language
         } else {
+            $name = "$Language".Trim()
+            # Map a display name (e.g. "German") to its Accept-Language code, as requests do
+            if ($name.Length -gt 3 -and $script:languagescsv) {
+                $code = ($script:languagescsv | Where-Object Name -eq $name | Select-Object -First 1).Code
+                if ($code) {
+                    $name = $code
+                }
+            }
             try {
-                Get-Date $date -Format "yyyy-MM-dd" -ErrorAction Stop
+                $culture = [System.Globalization.CultureInfo]::CreateSpecificCulture($name)
             } catch {
-                $null
+                $culture = $enus
             }
         }
-    } else {
-        $null
     }
+
+    $text = "$Date".Trim()
+    $styles = [System.Globalization.DateTimeStyles]::None
+    $parsed = [datetime]::MinValue
+
+    if ([datetime]::TryParse($text, $culture, $styles, [ref]$parsed)) {
+        return $parsed.ToString("yyyy-MM-dd", [System.Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    # Fall back to US parsing for already-normalized or US-format values (e.g. the local database)
+    if ($culture -ne $enus -and [datetime]::TryParse($text, $enus, $styles, [ref]$parsed)) {
+        return $parsed.ToString("yyyy-MM-dd", [System.Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    return $null
 }

--- a/public/Get-KbUpdate.ps1
+++ b/public/Get-KbUpdate.ps1
@@ -780,7 +780,7 @@ function Get-KbUpdate {
                         # may fix later
                         $ishotfix = $null
 
-                        $lastmod = Repair-Date $lastmodified
+                        $lastmod = Repair-Date -Date $lastmodified -Language $Language
 
                         $linkResults += [pscustomobject]@{
                             Title             = $title

--- a/tests/unit/Repair-Date.Tests.ps1
+++ b/tests/unit/Repair-Date.Tests.ps1
@@ -1,0 +1,62 @@
+BeforeAll {
+    $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    Import-Module (Join-Path $repositoryRoot 'kbupdate.psd1') -Force -ErrorAction Stop
+}
+
+Describe 'Repair-Date language-aware parsing (issue #167)' {
+    InModuleScope kbupdate {
+        Context 'US and database dates (no language)' {
+            It 'normalizes a US M/d/yyyy catalog date' {
+                Repair-Date -Date '7/8/2025' | Should -Be '2025-07-08'
+            }
+
+            It 'normalizes database-format dates with a two-digit day' {
+                Repair-Date -Date '10/26/2016' | Should -Be '2016-10-26'
+            }
+
+            It 'returns null for empty input' {
+                Repair-Date -Date $null | Should -BeNullOrEmpty
+                Repair-Date -Date '' | Should -BeNullOrEmpty
+            }
+
+            It 'normalizes a real DateTime regardless of thread culture' {
+                Repair-Date -Date ([datetime]'2020-01-15T09:30:00') | Should -Be '2020-01-15'
+            }
+        }
+
+        Context 'Localized catalog dates match the requested language' {
+            # The catalog returns 7/8/2025 (en-US), 08.07.2025 (de-DE) and 08/07/2025 (fr-FR)
+            # for the very same update (8 July 2025), localized to the Accept-Language header.
+            It 'parses a German dd.MM.yyyy date by language code' {
+                Repair-Date -Date '08.07.2025' -Language 'de-DE' | Should -Be '2025-07-08'
+            }
+
+            It 'parses a French dd/MM/yyyy date without swapping month and day' {
+                Repair-Date -Date '08/07/2025' -Language 'fr-FR' | Should -Be '2025-07-08'
+            }
+
+            It 'parses a German date whose day exceeds 12 (previously dropped)' {
+                Repair-Date -Date '18.06.2019' -Language 'de' | Should -Be '2019-06-18'
+            }
+
+            It 'resolves a language display name to its culture' {
+                Repair-Date -Date '18.06.2019' -Language 'German' | Should -Be '2019-06-18'
+            }
+        }
+
+        Context 'Resilience' {
+            It 'falls back to US parsing when a value is invalid for the language culture' {
+                # 3/25/2019 is not a valid de-DE d/M/yyyy date (month 25), so it falls back to US M/d/yyyy
+                Repair-Date -Date '3/25/2019' -Language 'de-DE' | Should -Be '2019-03-25'
+            }
+
+            It 'returns null for an unparseable value' {
+                Repair-Date -Date 'not a date' -Language 'de-DE' | Should -BeNullOrEmpty
+            }
+
+            It 'falls back to en-US for an unknown language' {
+                Repair-Date -Date '7/8/2025' -Language 'this-is-not-a-culture' | Should -Be '2025-07-08'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #167 ("Check if Language impacts date — i think it does"). It does, and the impact is silent date corruption.

The Microsoft Update Catalog **localizes the detail page's "Last Updated" date to the `Accept-Language` header** kbupdate sends for `-Language`. Verified live against the same update (8 July 2025):

| Request | `ScopedViewHandler_date` |
|---|---|
| en-US | `7/8/2025` (M/d/yyyy) |
| de-DE | `08.07.2025` (dd.MM.yyyy) |
| fr-FR | `08/07/2025` (dd/MM/yyyy) |

`Repair-Date` parsed **every** value as US `M/d/yyyy`, so a localized date was:
- **silently corrupted** by swapping month/day — `08.07.2025` (8 July) became **August 7**, and
- **dropped to null** when the day exceeded 12 — `18.06.2019` failed to parse (month 18).

It also parsed the US branch with `Get-Date`, which depends on the current **thread culture**, so even US dates could misparse on a non-US Windows box.

## Fix

- `Repair-Date` now parses with the **culture that matches the requested language** (resolving codes like `de`/`de-DE` and display names like `German` the same way `Invoke-TlsWebRequest` builds its `Accept-Language`), and normalizes a real `[datetime]` directly.
- The web call site passes `-Language`; the **local database stores US-format dates and is queried without a language, so the language-less default stays en-US** (no change there).
- Falls back to US parsing for values invalid in the requested culture; returns `$null` when truly unparseable.

## Tests

`tests/unit/Repair-Date.Tests.ps1` — deterministic, seeded with the exact localized strings observed live: US/database dates, German & French catalog dates (no month/day swap), a day-greater-than-12 case that previously nulled, language display-name resolution, DateTime input, and the US fallback.

## Verification

- `./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap`: 69 passed / 4 failed, where the only failures are the pre-existing `Start-BitsTransfer` tests that require the Windows-PowerShell BITS module (identical on clean `main`; green on the Windows CI runners).
- Localized date formats confirmed with a live read-only catalog probe (en-US / de-DE / fr-FR).
- Preserves Windows PowerShell 3.0 compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)