### PR TITLE
Clarify offline patching covers the full update history

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ If you can't update to WMF 5.0+, downloading patches using kbupdate then install
 
 kbupdate makes it much easier to patch your offline servers, all without SCCM or WSUS. It's basically a 5-step process.
 
-1. **Download** the needed patches from the Microsoft Update Catalog for the last 30 days
+1. **Download** patches from the Microsoft Update Catalog (the 30-day window below is just an example -- adjust or omit it)
 1. **Download** the WUA database which enables computers to check for needed updates
 1. **Burn** to DVD, along with kbupdate + required modules
 1. **Check** each server for needed updates against the wsusscn2.cab WUA database (`Save-KbScanFile`)
@@ -250,6 +250,12 @@ $params = @{
 }
 Install-KbUpdate @params
 ```
+
+### Machines that are far behind
+
+The `-Since (Get-Date).AddDays(-30)` filter above only limits the *pre-download* step; it is not a cap on what kbupdate can find. `wsusscn2.cab` is Microsoft's offline scan catalog and covers the **entire** history of security updates, so `Get-KbNeededUpdate`/`Install-KbUpdate -AllNeeded -ScanFilePath` will detect every needed update no matter how far behind a machine is (for example, a Windows 10 1703 box). When you point `-RepositoryPath` at a share, each target downloads exactly the files it needs, so you do not have to guess a date range up front.
+
+You also do not need to install NuGet, Visual Studio, or the module's build prerequisites on every client. The needed-update scan uses the Windows Update Agent (WUA), which is built into Windows, and the DSC install path copies the required helper modules to each target automatically. NuGet/PowerShellGet is only needed once on the internet-connected machine where you install kbupdate itself.
 
 ## Screenshots
 


### PR DESCRIPTION
## Summary

Fixes #212. The reporter (60 machines stuck on Windows 10 1703) read the offline-patching walkthrough as saying kbupdate "only goes back 30 days," and worried NuGet had to be installed on every client. Both concerns trace to the walkthrough's example, whose pre-download step used `-Since (Get-Date).AddDays(-30)` — which reads like a hard limit.

## Change (docs only)

In the **Offline patching** section of the README:
- Reworded step 1 so the 30-day window reads as an adjustable example, not a cap.
- Added a **"Machines that are far behind"** note explaining that `wsusscn2.cab` is Microsoft's offline scan catalog covering the *entire* update history, so `-AllNeeded -ScanFilePath` finds every needed update regardless of how far behind a machine is, and `-RepositoryPath` lets each target pull exactly what it needs.
- Clarified that clients need only the built-in **Windows Update Agent** (the scan uses WUA COM; the DSC install path copies helper modules to targets automatically) — NuGet/PowerShellGet is required just once, on the machine where kbupdate itself is installed.

All claims verified against the code (`Get-Needed` uses `Microsoft.Update.Session`; `Start-DscUpdate` auto-copies `xWindowsUpdate`/`xPSDesiredStateConfiguration` to targets; `-RepositoryPath` auto-downloads missing files).

## Verification

Docs-only change. `./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap` is unchanged (69 passed / 4 pre-existing `Start-BitsTransfer` environment failures, green on Windows CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)