### PR TITLE
Reset per-update state between AllNeeded install iterations

### DIFF
--- a/private/Start-DscUpdate.ps1
+++ b/private/Start-DscUpdate.ps1
@@ -186,6 +186,16 @@ function Start-DscUpdate {
         }
     }
     process {
+        # Preserve the originally-bound parameter values. When -AllNeeded (or a piped
+        # batch) sends several updates through the loop below in one invocation, each
+        # update must derive its own file, id, guid and title instead of reusing the
+        # first update's values -- see issue #203.
+        $originalHotfixId = $HotfixId
+        $originalFilePath = $FilePath
+        $originalGuid = $Guid
+        $originalTitle = $Title
+        $originalArgumentList = $ArgumentList
+
         if ($FilePath -and -not $InputObject) {
             Write-PSFMessage -Level Verbose -Message "Setting InputObject to $FilePath"
             $InputObject = $FilePath
@@ -194,6 +204,16 @@ function Start-DscUpdate {
             Write-PSFMessage -Level Verbose -Message "Nothing to install on $hostname, moving on"
         }
         foreach ($object in $InputObject) {
+            # Reset per-update state so one update's values never leak into the next (#203).
+            # The sticky "if (-not ...)" guards further down would otherwise keep the first
+            # update's file/id/guid for every subsequent update in an -AllNeeded batch.
+            $HotfixId = $originalHotfixId
+            $FilePath = $originalFilePath
+            $Guid = $originalGuid
+            $Title = $originalTitle
+            $ArgumentList = $originalArgumentList
+            $updatefile = $remotefile = $deleteremotefile = $file = $filename = $hotfix = $exists = $status = $message = $tempguid = $number = $null
+
             if ($object.Link -and $RepositoryPath) {
                 try {
                     foreach ($item in $object.Link) {

--- a/tests/unit/Start-DscUpdateReset.Tests.ps1
+++ b/tests/unit/Start-DscUpdateReset.Tests.ps1
@@ -1,0 +1,72 @@
+BeforeAll {
+    $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    Import-Module (Join-Path $repositoryRoot 'kbupdate.psd1') -Force -ErrorAction Stop
+}
+
+Describe 'Start-DscUpdate resets per-update state across a batch (issue #203)' {
+    InModuleScope kbupdate {
+        It 'installs each update''s own file and id instead of repeating the first' {
+            $u1 = [pscustomobject]@{
+                ComputerName = 'wks'
+                KBUpdate     = 'KB1111111'
+                UpdateId     = '11111111-1111-1111-1111-111111111111'
+                Title        = 'Security Update One'
+                Link         = @('https://catalog.s.download.windowsupdate.com/d/updateone_aaaa.exe')
+            }
+            $u2 = [pscustomobject]@{
+                ComputerName = 'wks'
+                KBUpdate     = 'KB2222222'
+                UpdateId     = '22222222-2222-2222-2222-222222222222'
+                Title        = 'Security Update Two'
+                Link         = @('https://catalog.s.download.windowsupdate.com/d/updatetwo_bbbb.exe')
+            }
+
+            # Keep everything on the local, no-network path so no real remoting/DSC/download runs.
+            # Import-Module is a no-op so Start-DscUpdate's job-context re-import does not re-run the
+            # module's initialization (which would rewrite PSFramework source config for later tests).
+            Mock Import-Module { }
+            Mock Invoke-KbCommand { 'C:\Users\test' }
+            Mock Get-KbInstalledSoftware { }
+            Mock Save-KbUpdate { }
+            Mock Copy-Item { }
+            Mock New-Item { }
+            Mock Write-Progress { }
+            Mock Test-Path { $true }
+            Mock Get-ChildItem {
+                param($Path)
+                $leaf = Split-Path -Path "$Path" -Leaf
+                $file = [pscustomobject]@{
+                    Name        = $leaf
+                    FullName    = "$Path"
+                    BaseName    = [System.IO.Path]::GetFileNameWithoutExtension($leaf)
+                    VersionInfo = [pscustomobject]@{ ProductName = $leaf }
+                }
+                # a real FileInfo stringifies to its path; the code relies on that (e.g. Split-Path -Leaf $updatefile)
+                $file | Add-Member -MemberType ScriptMethod -Name ToString -Value { $this.FullName } -Force -PassThru
+            }
+
+            $computer = [pscustomobject]@{ ComputerName = 'wks'; IsLocalHost = $true }
+
+            # Start-DscUpdate normally runs in an isolated job; called inline it mutates the shared
+            # $PSDefaultParameterValues (EnableException, Invoke-KbCommand:*). Snapshot and restore so
+            # this test does not leak defaults into later test files.
+            $savedDefaults = @{}
+            foreach ($key in $PSDefaultParameterValues.Keys) { $savedDefaults[$key] = $PSDefaultParameterValues[$key] }
+            try {
+                $raw = @(Start-DscUpdate -ComputerName $computer -IsLocalHost $true -InputObject @($u1, $u2) -ModulePath @((Get-Module kbupdate).Path) -EnableException)
+            } finally {
+                $PSDefaultParameterValues.Clear()
+                foreach ($key in $savedDefaults.Keys) { $PSDefaultParameterValues[$key] = $savedDefaults[$key] }
+            }
+            # Start-DscUpdate emits its install-summary objects (which carry a Status); ignore any
+            # incidental values that leak from uncaptured internal helper calls under mocking.
+            $result = @($raw | Where-Object { $_.PSObject.Properties.Name -contains 'Status' })
+
+            $result.Count | Should -Be 2
+            (@($result.FileName) | Sort-Object -Unique).Count | Should -Be 2
+            $result.FileName | Should -Contain 'updateone_aaaa.exe'
+            $result.FileName | Should -Contain 'updatetwo_bbbb.exe'
+            (@($result.ID) | Sort-Object -Unique).Count | Should -Be 2
+        }
+    }
+}


### PR DESCRIPTION
## Root cause (#203)

`Install-KbUpdate -AllNeeded -ScanFilePath wsusscn2.cab -RepositoryPath …` installed the **same** file repeatedly (report showed identical `ID` `729a0dcb…` and `FileName` `vcredist_x64…` for every distinct KB).

In `Start-DscUpdate`, the `-AllNeeded` path builds `$InputObject` from `Get-KbNeededUpdate` and loops over every needed update in **one** invocation. The per-update values are assigned with sticky `if (-not …)` guards and were never reset between iterations:
- `$FilePath` — `if (-not $FilePath)`
- `$HotfixId` — `if (-not $HotfixId)`
- `$Guid` — `if (-not $Guid)` → first update's `UpdateId`
- `$Title`, `$updatefile` — likewise sticky

So every update after the first reused the first update's file + identity — exactly the reported symptom. A read-only lab scan confirmed `Get-KbNeededUpdate` returns **distinct** links per update, so the collapse was purely in this loop.

## Fix

Capture the originally-bound parameter values, and at the top of each object iteration reset those plus the derived locals (`$updatefile`, `$remotefile`, `$deleteremotefile`, `$file`, `$filename`, `$hotfix`, `$exists`, `$status`, `$message`, `$tempguid`, `$number`) so each update resolves its own file/guid/id. Single-target and pipeline paths are unaffected (they reset to the same originally-bound values).

## Verification — deterministic regression test

`tests/unit/Start-DscUpdateReset.Tests.ps1` drives **two updates with distinct `UpdateId`/`Link`** through `Start-DscUpdate` on the local, fully-mocked path and asserts each summary reports its own file + id:

- **Fails on pre-fix code** — both rows come back as the first update (`11111111…` / `updateone_aaaa.exe` repeated), reproducing #203.
- **Passes with the fix** — each row is distinct (`updateone_aaaa.exe`/`11111111…`, `updatetwo_bbbb.exe`/`22222222…`).

No real install required. The test restores `$PSDefaultParameterValues` and no-ops the job-context module re-import so it stays isolated.

Full gate: **70 passed / 4 failed**, the 4 being the pre-existing `Start-BitsTransfer` env failures (green on Windows CI). `Install-KbUpdate` ShouldProcess tests still pass (single-target path intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
