### PR TITLE
Clear a busy LCM before invoking a DSC resource

### DIFF
--- a/private/Start-DscUpdate.ps1
+++ b/private/Start-DscUpdate.ps1
@@ -673,6 +673,34 @@ function Start-DscUpdate {
                     try {
                         $ProgressPreference = "SilentlyContinue"
 
+                        if (-not $workaround) {
+                            # A busy LCM (a periodic consistency check, or an earlier operation that is
+                            # still in progress) makes Invoke-DscResource fail with "Cannot invoke the
+                            # Invoke-DscResource cmdlet. The Consistency Check or Pull cmdlet is in
+                            # progress and must return before Invoke-DscResource can be invoked." Cancel
+                            # any in-progress operation and wait for the LCM to return to Idle first, so
+                            # the update can still be applied. Stop-DscConfiguration is asynchronous, so
+                            # polling for Idle avoids racing it. All of this is a no-op when the LCM is
+                            # already idle.
+                            try {
+                                for ($lcmwait = 0; $lcmwait -lt 30; $lcmwait++) {
+                                    $lcmstate = $null
+                                    try {
+                                        $lcmstate = (Get-DscLocalConfigurationManager -ErrorAction Stop).LCMState
+                                    } catch {
+                                        $lcmstate = $null
+                                    }
+                                    if (-not $lcmstate -or $lcmstate -eq "Idle") {
+                                        break
+                                    }
+                                    $null = Stop-DscConfiguration -Force -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+                                    Start-Sleep -Seconds 2
+                                }
+                            } catch {
+                                # the LCM does not support these operations; fall through to Invoke-DscResource
+                            }
+                        }
+
                         if ($workaround) {
                             $parms = @{
                                 Namespace    = "root/Microsoft/Windows/DesiredStateConfiguration"


### PR DESCRIPTION
## Problem

When a target machine's DSC **Local Configuration Manager (LCM) is busy** — running a periodic consistency check, or holding an operation that's still in progress — `Invoke-DscResource` fails immediately:

> Cannot invoke the Invoke-DscResource cmdlet. The Consistency Check or Pull cmdlet is in progress and must return before Invoke-DscResource can be invoked. Use -Force option if that is available to cancel the current operation.

kbupdate calls `Invoke-DscResource` ([Start-DscUpdate.ps1](private/Start-DscUpdate.ps1)) without first clearing an in-progress LCM operation, so an update install fails outright on any machine that happens to be mid-check. Found while verifying #202 on a lab client whose LCM was stuck in a consistency check.

## Fix

Before the `Test`/`Set` calls on the `Invoke-DscResource` path, cancel any in-progress operation and **wait for the LCM to return to `Idle`** before applying:

- Poll `Get-DscLocalConfigurationManager` for `LCMState`; if not `Idle`, `Stop-DscConfiguration -Force` and wait, up to ~60s.
- `Stop-DscConfiguration` is asynchronous, so invoking a resource immediately after it reproduces the same error — polling for `Idle` avoids that race.
- No-op when the LCM is already idle; bounded so a genuinely stuck LCM surfaces the original error after the timeout rather than hanging.

Note this cancels an in-progress LCM operation (a consistency check) so the requested update can be applied — which is exactly what the error message's "Use -Force to cancel" suggests.

## Verification (lab)

Reproduced and fixed on a real lab client (Windows PowerShell 5.1 → remote target):

- **Before:** target LCM `Busy` ("performing a consistency check") → install failed with the error above.
- The identical `Stop-DscConfiguration -Force` + poll-for-`Idle` sequence returned the stuck LCM to `Idle`.
- **After:** with the LCM idle, the install completed — `Status: Install successful`.

The clearing logic lives in the on-target DSC script block (run via `Invoke-KbCommand`), so it's verified on the lab rather than by a unit test. `./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap`: **70 passed / 4** (the 4 are the pre-existing `Start-BitsTransfer` env failures, green on Windows CI); the `Install-KbUpdate` ShouldProcess and `Start-DscUpdate` (#203) tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
