### PR TITLE
Return a summary for a successful install DSC reports as an error (#161)

### DIFF
--- a/private/Start-DscUpdate.ps1
+++ b/private/Start-DscUpdate.ps1
@@ -853,9 +853,6 @@ function Start-DscUpdate {
                     $filetitle = $Title
                 }
 
-                if ($message) {
-                    $status = "sucks"
-                }
                 [pscustomobject]@{
                     ComputerName = $hostname
                     Title        = $filetitle
@@ -946,8 +943,57 @@ function Start-DscUpdate {
                         FileName     = $updatefile.Name
                     }
                 } else {
-                    Pop-Location
-                    Stop-PSFFunction -Message "Failure on $hostname" -ErrorRecord $PSitem -Continue -EnableException:$EnableException
+                    # A successful install can still surface a message that DSC treats as an error
+                    # (notably SQL Server cumulative updates), which previously produced no summary at
+                    # all (#161). Confirm whether the update actually installed before reporting failure,
+                    # and still return a summary when it did.
+                    $exists = $null
+                    $checkpattern = $HotfixId
+                    if (-not $checkpattern) {
+                        $checkpattern = $hotfix.property.id
+                    }
+                    if ($checkpattern) {
+                        $exists = Get-KbInstalledSoftware -ComputerName $ComputerName -Pattern $checkpattern -IncludeHidden -Credential $Credential
+                    }
+
+                    if (-not $exists) {
+                        Pop-Location
+                        Stop-PSFFunction -Message "Failure on $hostname" -ErrorRecord $PSitem -Continue -EnableException:$EnableException
+                    } else {
+                        if ($exists.Summary -match "restart") {
+                            $status = "Install successful. This update requires a restart."
+                        } else {
+                            $status = "Install successful"
+                        }
+
+                        if ($HotfixId) {
+                            $id = $HotfixId
+                        } else {
+                            $id = $guid
+                        }
+                        if ($id -eq "DAADB00F-DAAD-B00F-B00F-DAADB00FB00F") {
+                            $id = $null
+                        }
+
+                        if ($object.Title) {
+                            $filetitle = $object.Title
+                        } elseif ($exists.Title) {
+                            $filetitle = $exists.Title
+                        } else {
+                            $filetitle = $updatefile.VersionInfo.ProductName
+                        }
+                        if (-not $filetitle) {
+                            $filetitle = $Title
+                        }
+
+                        [pscustomobject]@{
+                            ComputerName = $hostname
+                            Title        = $filetitle
+                            ID           = $id
+                            Status       = $status
+                            FileName     = $updatefile.Name
+                        }
+                    }
                 }
             }
         }

--- a/tests/unit/Start-DscUpdateSummary.Tests.ps1
+++ b/tests/unit/Start-DscUpdateSummary.Tests.ps1
@@ -1,0 +1,63 @@
+BeforeAll {
+    $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+    Import-Module (Join-Path $repositoryRoot 'kbupdate.psd1') -Force -ErrorAction Stop
+}
+
+Describe 'Start-DscUpdate returns a summary for a successful install that DSC reports as an error (issue #161)' {
+    InModuleScope kbupdate {
+        It 'still emits a summary when the install threw an unrecognized message but the update is present' {
+            $sqlcu = [pscustomobject]@{
+                ComputerName = 'sql01'
+                KBUpdate     = 'KB5016394'
+                UpdateId     = 'aaaaaaaa-1111-2222-3333-444444444444'
+                Title        = 'Cumulative Update 17 for SQL Server 2019 (KB5016394)'
+                Link         = @('https://catalog.s.download.windowsupdate.com/d/sqlserver2019-kb5016394-x64_deadbeef.exe')
+            }
+
+            # Local, fully-mocked path so nothing real runs.
+            Mock Import-Module { }
+            Mock Invoke-KbCommand { 'C:\Users\test' }
+            # The actual DSC install (only this call uses WarningVariable 'dscwarnings') throws a
+            # message that is not one of the specially-handled ones -- as a SQL CU can.
+            Mock Invoke-KbCommand -ParameterFilter { $WarningVariable -eq 'dscwarnings' } {
+                throw 'The return code 3010 was not expected. Configuration of the additional properties may be needed.'
+            }
+            # ...but the update is in fact installed on the target.
+            Mock Get-KbInstalledSoftware {
+                [pscustomobject]@{ Title = 'Hotfix 5016394 for SQL Server 2019'; Summary = 'Installed' }
+            }
+            Mock Save-KbUpdate { }
+            Mock Copy-Item { }
+            Mock New-Item { }
+            Mock Write-Progress { }
+            Mock Test-Path { $true }
+            Mock Get-ChildItem {
+                param($Path)
+                $leaf = Split-Path -Path "$Path" -Leaf
+                $file = [pscustomobject]@{
+                    Name        = $leaf
+                    FullName    = "$Path"
+                    BaseName    = [System.IO.Path]::GetFileNameWithoutExtension($leaf)
+                    VersionInfo = [pscustomobject]@{ ProductName = $leaf }
+                }
+                $file | Add-Member -MemberType ScriptMethod -Name ToString -Value { $this.FullName } -Force -PassThru
+            }
+
+            $savedDefaults = @{}
+            foreach ($key in $PSDefaultParameterValues.Keys) { $savedDefaults[$key] = $PSDefaultParameterValues[$key] }
+            try {
+                $raw = @(Start-DscUpdate -ComputerName 'sql01' -IsLocalHost $true -HotfixId 'KB5016394' -InputObject @($sqlcu) -ModulePath @((Get-Module kbupdate).Path) -EnableException)
+            } finally {
+                $PSDefaultParameterValues.Clear()
+                foreach ($key in $savedDefaults.Keys) { $PSDefaultParameterValues[$key] = $savedDefaults[$key] }
+            }
+
+            $summary = @($raw | Where-Object { $_.PSObject.Properties.Name -contains 'Status' })
+
+            $summary.Count | Should -Be 1
+            $summary[0].Status | Should -Match 'Install successful'
+            $summary[0].ID | Should -Be 'KB5016394'
+            $summary[0].ComputerName | Should -Be 'sql01'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #161 — installing a SQL Server CU worked but returned no summary object at the end.

## Root cause

After the DSC install, `Start-DscUpdate`'s outer error handler has three branches. Two of them (`"Serialized XML is nested too deeply"` and `"find message text"`) recover and still emit the install summary — but the final **`else` branch just called `Stop-PSFFunction` and returned nothing**.

A SQL Server cumulative update can **install successfully yet make DSC throw a message that isn't one of the specially-handled ones** (e.g. an unexpected return code). That lands in the `else` branch, so the update installs but no summary comes back — exactly the report.

## Fix

In the `else` branch, before reporting failure, confirm whether the update is actually present (`Get-KbInstalledSoftware`, keyed on the HotfixId / package id) and, if so, emit the install summary — mirroring what the `"find message text"` recovery branch already does. Genuine failures (update not present) still `Stop-PSFFunction` as before.

Also removed a leftover debug line that set the status to `"sucks"`.

## Tests

`tests/unit/Start-DscUpdateSummary.Tests.ps1` drives `Start-DscUpdate` on the local, fully-mocked path where the DSC install throws an unrecognized message (`"The return code 3010 was not expected…"`) while the update *is* present on the target. It asserts a summary with `Status = "Install successful"` and the right `ID`/`ComputerName` is still returned.

- **Fails on pre-fix code** (the `else` branch returns nothing → 0 summary objects).
- **Passes with the fix.**

No real SQL CU download/install needed.

## Verification

`./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap`: **71 passed / 4** — the 4 are the pre-existing `Start-BitsTransfer` env failures (green on Windows CI). The `Install-KbUpdate` ShouldProcess and `Start-DscUpdate` (#203) tests still pass; no cross-test contamination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
