### PR TITLE
Wait for busy DSC operations without cancelling them

### DIFF
--- a/private/Start-DscUpdate.ps1
+++ b/private/Start-DscUpdate.ps1
@@ -674,30 +674,30 @@ function Start-DscUpdate {
                         $ProgressPreference = "SilentlyContinue"
 
                         if (-not $workaround) {
-                            # A busy LCM (a periodic consistency check, or an earlier operation that is
-                            # still in progress) makes Invoke-DscResource fail with "Cannot invoke the
-                            # Invoke-DscResource cmdlet. The Consistency Check or Pull cmdlet is in
-                            # progress and must return before Invoke-DscResource can be invoked." Cancel
-                            # any in-progress operation and wait for the LCM to return to Idle first, so
-                            # the update can still be applied. Stop-DscConfiguration is asynchronous, so
-                            # polling for Idle avoids racing it. All of this is a no-op when the LCM is
-                            # already idle.
-                            try {
-                                for ($lcmwait = 0; $lcmwait -lt 30; $lcmwait++) {
+                            # A busy LCM (a periodic consistency check, or an operation still in progress)
+                            # makes Invoke-DscResource fail with "Cannot invoke the Invoke-DscResource
+                            # cmdlet. The Consistency Check or Pull cmdlet is in progress and must return
+                            # before Invoke-DscResource can be invoked." Wait for the LCM to return to Idle
+                            # rather than forcibly cancelling whatever it is doing -- that could be an
+                            # unrelated consistency check, pull, or configuration on the target. This is a
+                            # no-op when the LCM is already idle; if it stays busy, surface an actionable
+                            # message instead of the raw DSC error.
+                            $lcmstate = $null
+                            for ($lcmwait = 0; $lcmwait -lt 30; $lcmwait++) {
+                                try {
+                                    $lcmstate = (Get-DscLocalConfigurationManager -ErrorAction Stop).LCMState
+                                } catch {
+                                    # the LCM cannot be queried on this system; let Invoke-DscResource proceed
                                     $lcmstate = $null
-                                    try {
-                                        $lcmstate = (Get-DscLocalConfigurationManager -ErrorAction Stop).LCMState
-                                    } catch {
-                                        $lcmstate = $null
-                                    }
-                                    if (-not $lcmstate -or $lcmstate -eq "Idle") {
-                                        break
-                                    }
-                                    $null = Stop-DscConfiguration -Force -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
-                                    Start-Sleep -Seconds 2
+                                    break
                                 }
-                            } catch {
-                                # the LCM does not support these operations; fall through to Invoke-DscResource
+                                if (-not $lcmstate -or $lcmstate -eq "Idle") {
+                                    break
+                                }
+                                Start-Sleep -Seconds 2
+                            }
+                            if ($lcmstate -and $lcmstate -ne "Idle") {
+                                throw "The Local Configuration Manager on $env:ComputerName is busy ($lcmstate) and did not return to Idle within 60 seconds. Another DSC operation (a consistency check, pull, or configuration) is in progress. Wait for it to finish, or run 'Stop-DscConfiguration -Force' on the target to cancel it, then try again."
                             }
                         }
 

--- a/tests/unit/Start-DscUpdateReset.Tests.ps1
+++ b/tests/unit/Start-DscUpdateReset.Tests.ps1
@@ -60,7 +60,7 @@ Describe 'Start-DscUpdate resets per-update state across a batch (issue #203)' {
             }
             # Start-DscUpdate emits its install-summary objects (which carry a Status); ignore any
             # incidental values that leak from uncaptured internal helper calls under mocking.
-            $result = @($raw | Where-Object { $_.PSObject.Properties.Name -contains 'Status' })
+            $result = @($raw | Where-Object { $PSItem.PSObject.Properties.Name -contains 'Status' })
 
             $result.Count | Should -Be 2
             (@($result.FileName) | Sort-Object -Unique).Count | Should -Be 2

--- a/tests/unit/Start-DscUpdateSummary.Tests.ps1
+++ b/tests/unit/Start-DscUpdateSummary.Tests.ps1
@@ -52,7 +52,7 @@ Describe 'Start-DscUpdate returns a summary for a successful install that DSC re
                 foreach ($key in $savedDefaults.Keys) { $PSDefaultParameterValues[$key] = $savedDefaults[$key] }
             }
 
-            $summary = @($raw | Where-Object { $_.PSObject.Properties.Name -contains 'Status' })
+            $summary = @($raw | Where-Object { $PSItem.PSObject.Properties.Name -contains 'Status' })
 
             $summary.Count | Should -Be 1
             $summary[0].Status | Should -Match 'Install successful'


### PR DESCRIPTION
## What changed

- Wait up to 60 seconds for a busy DSC Local Configuration Manager to become idle.
- Stop automatically calling `Stop-DscConfiguration -Force` on the target.
- Return an actionable timeout error when another DSC operation remains busy.
- Use the repository-preferred `$PSItem` form in the two affected regression tests.

## Why

The current busy-LCM handling can forcibly cancel an unrelated consistency check, pull, or configuration on a target machine. Because update installation is production-impacting, kbupdate should not cancel other DSC work implicitly. A bounded wait preserves the original retry behavior without making that destructive choice for the operator.

## User impact

An install waits for ordinary DSC contention to clear. If it does not clear within 60 seconds, the command explains how the operator can explicitly cancel the other operation before retrying.

## Verification

- `./build/Invoke-KbUpdateQualityGate.ps1 -Bootstrap` — 75 passed, 0 failed
- `./build/Invoke-KbUpdateIntegration.ps1` — 6 passed, 0 failed, 3 intentionally skipped
- Confirmed current `main` Quality gate run is green; GitHub has no scheduled Actions runs or open PRs with failing checks.